### PR TITLE
Scalebar

### DIFF
--- a/src/gov/nasa/cms/features/MeasureDialog.java
+++ b/src/gov/nasa/cms/features/MeasureDialog.java
@@ -91,7 +91,7 @@ public class MeasureDialog
         dialog.getContentPane().setLayout(new BorderLayout());
         dialog.setTitle("Measure Tool");
         // Set the location and resizable to false
-        dialog.setLocation(bounds.x, bounds.y + 90);
+        dialog.setLocation(bounds.x, bounds.y + 70); //originally at 90
         dialog.setResizable(false);
         // Add the tabbedPane to the dialog
         dialog.getContentPane().add(tabbedPane, BorderLayout.CENTER);

--- a/src/gov/nasa/worldwind/layers/ScalebarLayer.java
+++ b/src/gov/nasa/worldwind/layers/ScalebarLayer.java
@@ -611,7 +611,7 @@ public class ScalebarLayer extends AbstractLayer
         else if (this.position.equals(AVKey.CENTER))
         {
             x = viewport.getWidth() / 2 - scaledWidth / 2;
-            y = viewport.getHeight() / 2 - scaledHeight - 350;
+            y = 0d + this.borderWidth;
         }
         else // use North East
         {

--- a/src/gov/nasa/worldwind/layers/ScalebarLayer.java
+++ b/src/gov/nasa/worldwind/layers/ScalebarLayer.java
@@ -611,7 +611,7 @@ public class ScalebarLayer extends AbstractLayer
         else if (this.position.equals(AVKey.CENTER))
         {
             x = viewport.getWidth() / 2 - scaledWidth / 2;
-            y = viewport.getHeight() / 2 - 2*scaledHeight;
+            y = viewport.getHeight() / 2 - scaledHeight - 350;
         }
         else // use North East
         {


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Scalebar position moved to bottom center of application screen. 

### Why Should This Be In Core?
The updated scalebar position allows users to view celestial object with convenient frame of reference without having to shift eyes back and forth from top left (original position) to center screen. 

### Benefits
Convenient scalebar viewing on celestial surface. 
Scalebar is at optimal location on both full screen and load screen. 

### Potential Drawbacks
Could potentially argue that the scalebar obstructs view of lunar surface. 

### Applicable Issues
N/A