### PR TITLE
Apollo landing site position changes

### DIFF
--- a/src/gov/nasa/cms/CMSColladaViewer.java
+++ b/src/gov/nasa/cms/CMSColladaViewer.java
@@ -44,63 +44,63 @@ public class CMSColladaViewer {
         switch (location)
         {
             case "Apollo 11" :
-                Position LunarLanderPosition = Position.fromDegrees(0.6875, 23.4993, 100);
+                Position LunarLanderPosition = Position.fromDegrees(0.6875, 23.4993, 0);
                 createLanderObject(LunarLanderPosition);
 
-                Position FirstAstronautPosition = Position.fromDegrees(0.6862, 23.4823, 100);
+                Position FirstAstronautPosition = Position.fromDegrees(0.6862, 23.4823, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                Position SecondAstronautPosition = Position.fromDegrees(0.6623, 23.4933, 100);
+                Position SecondAstronautPosition = Position.fromDegrees(0.6623, 23.4933, 0);
                 createSecondAstronaut(SecondAstronautPosition);
                 break;
             case "Apollo 12" :
-                LunarLanderPosition = Position.fromDegrees(-3.01, -23.43, 100);
+                LunarLanderPosition = Position.fromDegrees(-3.01, -23.43, 0);
                 createLanderObject(LunarLanderPosition);
 
-                FirstAstronautPosition = Position.fromDegrees(-3.06, -23.43, 100);
+                FirstAstronautPosition = Position.fromDegrees(-3.06, -23.43, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                SecondAstronautPosition = Position.fromDegrees(-2.95, -23.43, 100);
+                SecondAstronautPosition = Position.fromDegrees(-2.95, -23.43, 0);
                 createSecondAstronaut(SecondAstronautPosition);
                 break;
             case "Apollo 14" :
-                LunarLanderPosition = Position.fromDegrees(-3.66, -17.4786, 100);
+                LunarLanderPosition = Position.fromDegrees(-3.66, -17.4786, 0);
                 createLanderObject(LunarLanderPosition);
 
-                FirstAstronautPosition = Position.fromDegrees(-3.6720, -17.4453, 100);
+                FirstAstronautPosition = Position.fromDegrees(-3.6720, -17.4453, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                SecondAstronautPosition = Position.fromDegrees(-3.6845, -17.4853, 100);
+                SecondAstronautPosition = Position.fromDegrees(-3.6845, -17.4853, 0);
                 createSecondAstronaut(SecondAstronautPosition);
                 break;
             case "Apollo 15" :
-                LunarLanderPosition = Position.fromDegrees(26.1008, 3.6527, 100);
+                LunarLanderPosition = Position.fromDegrees(26.1008, 3.6527, 0);
                 createLanderObject(LunarLanderPosition);
 
-                FirstAstronautPosition = Position.fromDegrees(26.0970, 3.6017, 100);
+                FirstAstronautPosition = Position.fromDegrees(26.0970, 3.6017, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                SecondAstronautPosition = Position.fromDegrees(26.118, 3.6987, 100);
+                SecondAstronautPosition = Position.fromDegrees(26.118, 3.6987, 0);
                 createSecondAstronaut(SecondAstronautPosition);
                 break;
             case "Apollo 16" :
-                LunarLanderPosition = Position.fromDegrees(-8.9913, 15.5144, 100);
+                LunarLanderPosition = Position.fromDegrees(-8.9913, 15.5144, 0);
                 createLanderObject(LunarLanderPosition);
 
-                FirstAstronautPosition = Position.fromDegrees(-8.9899, 15.4944, 100);
+                FirstAstronautPosition = Position.fromDegrees(-8.9899, 15.4944, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                SecondAstronautPosition = Position.fromDegrees(-8.9999, 15.5344, 100);
+                SecondAstronautPosition = Position.fromDegrees(-8.9999, 15.5344, 0);
                 createSecondAstronaut(SecondAstronautPosition);
                 break;
             case "Apollo 17" : 
-                LunarLanderPosition = Position.fromDegrees(20.1653, 30.7658, 100);
+                LunarLanderPosition = Position.fromDegrees(20.1653, 30.7658, 0);
                 createLanderObject(LunarLanderPosition);
 
-                FirstAstronautPosition = Position.fromDegrees(20.1640, 30.7255, 100);
+                FirstAstronautPosition = Position.fromDegrees(20.1640, 30.7255, 0);
                 createFirstAstronaut(FirstAstronautPosition);
                  
-                SecondAstronautPosition = Position.fromDegrees(20.12, 30.7461, 100);
+                SecondAstronautPosition = Position.fromDegrees(20.12, 30.7461, 0);
                 createSecondAstronaut(SecondAstronautPosition);;
                 break;
             default :

--- a/src/gov/nasa/cms/features/ApolloMenu.java
+++ b/src/gov/nasa/cms/features/ApolloMenu.java
@@ -135,7 +135,7 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 14");
 
-                    zoomTo(LatLon.fromDegrees(-3.7, -17.5), Angle.fromDegrees(30), Angle.fromDegrees(75), 2200);
+                    zoomTo(LatLon.fromDegrees(-3.7, -17.5), Angle.fromDegrees(30), Angle.fromDegrees(75), 2600);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo14);
@@ -220,7 +220,7 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 17");
 
-                    zoomTo(LatLon.fromDegrees(20.15, 30.67), Angle.fromDegrees(90), Angle.fromDegrees(70), 2500);
+                    zoomTo(LatLon.fromDegrees(20.15, 30.72), Angle.fromDegrees(90), Angle.fromDegrees(70), 2800);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo17);

--- a/src/gov/nasa/cms/features/ApolloMenu.java
+++ b/src/gov/nasa/cms/features/ApolloMenu.java
@@ -19,9 +19,11 @@ import javax.swing.JMenu;
 /**
  * Apollo Menu bar created from a JMenu. The menu uses
  * {@link gov.nasa.cms.features.ApolloAnnotations} to display the Annotations
- * feature and five Apollo landing sites as JCheckBoxMenuItems. The landing
+ * feature and six Apollo landing sites as JCheckBoxMenuItems. The landing
  * sites use approximate Apollo landing coordinates to place the user in a good
  * location for viewing surroundings.
+ * 
+ * Landing sites display Collada 3D Astronauts and the Lunar Lander.
  *
  *
  * @author kjdickin
@@ -78,7 +80,7 @@ public class ApolloMenu extends JMenu
 
                     colladaViewer.createObjects("Apollo 11");
                     // Zoom to a close up view of the Apollo landing site
-                    zoomTo(LatLon.fromDegrees(0.67, 23.48), Angle.fromDegrees(10), Angle.fromDegrees(70), 2000);                   
+                    zoomTo(LatLon.fromDegrees(0.67, 23.49), Angle.fromDegrees(30), Angle.fromDegrees(75), 2100);                   
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo11); // Removes Apollo 11 from LayerList
@@ -105,7 +107,7 @@ public class ApolloMenu extends JMenu
                     apollo12.setEnabled(true);
                     layerList.add(apollo12);
                     colladaViewer.createObjects("Apollo 12");
-                    zoomTo(LatLon.fromDegrees(-3.01, -23.43), Angle.fromDegrees(10), Angle.fromDegrees(70), 1200);
+                    zoomTo(LatLon.fromDegrees(-3.07, -23.44), Angle.fromDegrees(20), Angle.fromDegrees(75), 2500);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo12);
@@ -133,7 +135,7 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 14");
 
-                    zoomTo(LatLon.fromDegrees(-3.66, -17.4786), Angle.fromDegrees(10), Angle.fromDegrees(70), 1200);
+                    zoomTo(LatLon.fromDegrees(-3.7, -17.5), Angle.fromDegrees(30), Angle.fromDegrees(75), 2200);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo14);
@@ -161,12 +163,12 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 15");
 
-                    zoomTo(LatLon.fromDegrees(26, 3.5), Angle.fromDegrees(90), Angle.fromDegrees(70), 3e4);
+                    zoomTo(LatLon.fromDegrees(26.1, 3.65), Angle.fromDegrees(140), Angle.fromDegrees(80), 4300);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo15);
                     colladaViewer.removeColladaObjects();
-                    zoomTo(LatLon.fromDegrees(0, 0), Angle.fromDegrees(0), Angle.fromDegrees(0), 8e6);
+                    zoomTo(LatLon.fromDegrees(0, 0), Angle.fromDegrees(20), Angle.fromDegrees(0), 8e6);
                 }
 
             }
@@ -190,7 +192,7 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 16");
 
-                    zoomTo(LatLon.fromDegrees(-8.9975, 15.47), Angle.fromDegrees(0), Angle.fromDegrees(70), 2500);
+                    zoomTo(LatLon.fromDegrees(-8.9975, 15.51), Angle.fromDegrees(40), Angle.fromDegrees(75), 3000);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo16);
@@ -218,7 +220,7 @@ public class ApolloMenu extends JMenu
                     
                     colladaViewer.createObjects("Apollo 17");
 
-                    zoomTo(LatLon.fromDegrees(20, 30.6), Angle.fromDegrees(30), Angle.fromDegrees(70), 3e4);
+                    zoomTo(LatLon.fromDegrees(20.15, 30.67), Angle.fromDegrees(90), Angle.fromDegrees(70), 2500);
                 } else
                 {
                     getWwd().getModel().getLayers().remove(apollo17);


### PR DESCRIPTION
### Description of the Change
Modified positions on Apollo landing sites to zoom in closer to 3D objects and changed elevation for Lunar Lander and Astronauts.

### Why Should This Be In Core?
Good viewing of 3D objects and surroundings.

### Benefits
Easier to view 3D objects; Lunar Lander and Astronauts are even with the terrain.

### Potential Drawbacks
User must zoom out more to view entire landing site.

### Applicable Issues