### PR TITLE
Reset button

### DIFF
--- a/src/gov/nasa/cms/CelestialMapper.java
+++ b/src/gov/nasa/cms/CelestialMapper.java
@@ -50,9 +50,11 @@ public class CelestialMapper extends AppFrame
     
     private boolean stereo;
     private boolean isMeasureDialogOpen;
+    private boolean resetWindow;
 
     private JCheckBoxMenuItem stereoCheckBox;
     private JCheckBoxMenuItem measurementCheckBox;
+    private JCheckBoxMenuItem reset;
 
     public void restart()
     {
@@ -195,9 +197,24 @@ public class CelestialMapper extends AppFrame
                 }
                 restart();
             });
-            view.add(stereoCheckBox);            
+            view.add(stereoCheckBox);     
+            
+            //======== "Reset" =========
+            reset = new JCheckBoxMenuItem("Reset");
+            reset.setSelected(resetWindow);
+            reset.addActionListener((ActionEvent event) ->
+            {
+                resetWindow = !resetWindow;
+                if (resetWindow)
+                {
+                    restart(); //resets window to launch status
+                    reset.doClick(1);
+                } 
+            });
+            view.add(reset);
         }
         menuBar.add(view);
+        
         frame.setJMenuBar(menuBar);
     }
 

--- a/src/gov/nasa/cms/features/ApolloMenu.java
+++ b/src/gov/nasa/cms/features/ApolloMenu.java
@@ -41,7 +41,7 @@ public class ApolloMenu extends JMenu
     private Layer apollo15;
     private Layer apollo16;
     private Layer apollo17;
-    private CMSColladaViewer colladaViewer;
+    private final CMSColladaViewer colladaViewer;
 
     public ApolloMenu(WorldWindow Wwd)
     {
@@ -62,7 +62,7 @@ public class ApolloMenu extends JMenu
         apollo = new ApolloAnnotations(this.getWwd());
         this.add(apollo);
 
-        //======== Apollo 12 ========   
+        //======== Apollo 11 ========   
         JCheckBoxMenuItem apolloMenuItem = new JCheckBoxMenuItem("Apollo 11");
         apolloMenuItem.addActionListener(new ActionListener()
         {
@@ -232,11 +232,8 @@ public class ApolloMenu extends JMenu
         });
         this.add(apolloMenuItem);
         
-//        //======== 3D Objects ========   
-//        colladaViewer = new CMSColladaViewer(this.getWwd());
-//        this.add(colladaViewer);
     }
-
+    
     // Zooms to the landing site at the passed in latitude/longitude, heading, pitch and zoom level
     protected void zoomTo(LatLon latLon, Angle heading, Angle pitch, double zoom)
     {


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Reset button that resets the CMS window to launch status is added under View menu as a menu item. 

### Why Should This Be In Core?
Increased convenience in CMS navigation. 

### Benefits
Convenient to return to original canvas without disabling enabled features. 
When using the controls to various angles and degrees of the globe, or having enabled various place names and other features, disabling all the items and returning to the original view can be cumbersome. 
Adding a reset button bypasses the inconvenience and extra steps to return to normal view. 

### Potential Drawbacks
Could decide the Reset button would be better placed elsewhere. 

### Applicable Issues