### PR TITLE
Global Area Reference System (GARS) graticule

### DIFF
--- a/src/config/worldwind.layers.xml
+++ b/src/config/worldwind.layers.xml
@@ -25,7 +25,10 @@
     <Layer href="cms-data/layers/LunarOrbiterGlobalMosaic.xml" actuate="onRequest"/>
                  
     <Layer className="gov.nasa.worldwind.layers.LatLonGraticuleLayer" actuate="onRequest">
-        <Property name="Name" value="Graticule"/>
+        <Property name="Name" value="Lat-Lon Graticule"/>
+    </Layer>/>
+    <Layer className="gov.nasa.worldwind.layers.GARSGraticuleLayer" actuate="onRequest">
+        <Property name="Name" value="GARS Graticule"/>
     </Layer>/>
     <Layer className="gov.nasa.worldwind.layers.ScalebarLayer"/>
 </LayerList>


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Added GARS graticule that complements LatLon graticule

### Why Should This Be In Core?
Upgraded graticule viewing for global area reference system. 

### Benefits
This enables higher level surface observance. 
DOD-centric feature. 

### Potential Drawbacks
Could look into separating LatLon graticule and GARS graticule from layer list and into its own separate button to declutter layre list panel. 

### Applicable Issues
n/a