### PR TITLE
Elevation model rescale

### DIFF
--- a/src/gov/nasa/cms/AppFrame.java
+++ b/src/gov/nasa/cms/AppFrame.java
@@ -23,41 +23,15 @@ public class AppFrame extends JFrame {
 
     protected AppPanel wwjPanel;
     protected JPanel controlPanel;
-//    protected LayerPanel layerPanel;
-//    protected StatisticsPanel statsPanel;
 
-//    public AppFrame() {
-    //  this.initializeAppframe(); //true, true, false);
-//    }
-//    public AppFrame(Dimension size) {
-//        this.canvasSize = size;
-//        this.initialize(true, true, false);
-//    }
-//
-//    public AppFrame(boolean includeStatusBar, boolean includeLayerPanel, boolean includeStatsPanel) {
-//        this.initialize(includeStatusBar, includeLayerPanel, includeStatsPanel);
-//    }
-//    protected void initialize(boolean includeStatusBar, boolean includeLayerPanel, boolean includeStatsPanel) {
     public void initialize() {
         // Create the WorldWindow.
         this.wwjPanel = new AppPanel(this.canvasSize); //, includeStatusBar);
         this.wwjPanel.setPreferredSize(canvasSize);
 
-        // Put the pieces together.
+        // Add the panel to the content pane
         this.getContentPane().add(wwjPanel, BorderLayout.CENTER);
-//        if (includeLayerPanel) {
-//            this.controlPanel = new JPanel(new BorderLayout(10, 10));
-//            this.layerPanel = new LayerPanel(this.getWwd());
-//            this.controlPanel.add(this.layerPanel, BorderLayout.CENTER);
-//            this.controlPanel.add(new FlatWorldPanel(this.getWwd()), BorderLayout.NORTH);
-//            this.getContentPane().add(this.controlPanel, BorderLayout.WEST);
-//        }
-//
-//        if (includeStatsPanel || System.getProperty("gov.nasa.worldwind.showStatistics") != null) {
-//            this.statsPanel = new StatisticsPanel(this.wwjPanel.getWwd(), new Dimension(250, canvasSize.height));
-//            this.getContentPane().add(this.statsPanel, BorderLayout.EAST);
-//        }
-
+        
         // Create and install the view controls layer and register a controller for it with the WorldWindow.
         ViewControlsLayer viewControlsLayer = new ViewControlsLayer();
         insertBeforeCompass(getWwd(), viewControlsLayer);
@@ -91,10 +65,7 @@ public class AppFrame extends JFrame {
         WWUtil.alignComponent(null, this, AVKey.CENTER);
         this.setResizable(true);
     }
-
-//    protected AppPanel createAppPanel(Dimension canvasSize) { //, boolean includeStatusBar) {
-//        return new AppPanel(canvasSize); //, includeStatusBar);
-//    }
+    
     public Dimension getCanvasSize() {
         return canvasSize;
     }
@@ -106,9 +77,6 @@ public class AppFrame extends JFrame {
     public WorldWindow getWwd() {
         return this.wwjPanel.getWwd();
     }
-//        public void setWwd(WorldWindow NewWwd) {
-//            this.wwjPanel.setWwd(NewWwd);
-//        }
 
     public StatusBar getStatusBar() {
         return this.wwjPanel.getStatusBar();
@@ -118,18 +86,11 @@ public class AppFrame extends JFrame {
      * @deprecated Use getControlPanel instead.
      * @return This application's layer panel.
      */
-//    @Deprecated
-//    public LayerPanel getLayerPanel() {
-//        return this.layerPanel;
-//    }
     @Deprecated
     public JPanel getControlPanel() {
         return this.controlPanel;
     }
 
-//    public StatisticsPanel getStatsPanel() {
-//        return statsPanel;
-//    }
     public void setToolTipController(ToolTipController controller) {
         if (this.wwjPanel.toolTipController != null) {
             this.wwjPanel.toolTipController.dispose();
@@ -207,24 +168,4 @@ public class AppFrame extends JFrame {
         }
 
     }
-
-//    public static AppFrame start(String appName) { //, Class<?> appFrameClass) {
-//        if (Configuration.isMacOS() && appName != null) {
-//            System.setProperty("com.apple.mrj.application.apple.menu.about.name", appName);
-//        }
-//
-//        try {
-//            final AppFrame frame = (AppFrame) appFrameClass.getConstructor().newInstance();
-//            frame.setTitle(appName);
-//            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-//            java.awt.EventQueue.invokeLater(() -> {
-//                frame.setVisible(true);
-//            });
-//
-//            return frame;
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//            return null;
-//        }
-//    }
 }

--- a/src/gov/nasa/cms/CelestialMapper.java
+++ b/src/gov/nasa/cms/CelestialMapper.java
@@ -13,19 +13,16 @@ import gov.nasa.cms.features.MeasureDialog;
 import gov.nasa.cms.features.MoonElevationModel;
 import gov.nasa.cms.features.SatelliteObject;
 import gov.nasa.worldwind.Configuration;
-import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.util.measure.MeasureTool;
 import gov.nasa.worldwind.layers.*;
 import gov.nasa.worldwind.WorldWindow;
 import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.Angle;
-import gov.nasa.worldwind.geom.LatLon;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.geom.Sector;
 import gov.nasa.worldwind.globes.EarthFlat;
 import gov.nasa.worldwind.render.ScreenImage;
 import gov.nasa.worldwind.util.Logging;
-import gov.nasa.worldwind.view.orbit.BasicOrbitView;
 import java.awt.Point;
 import java.awt.Rectangle;
 import javax.swing.*;
@@ -198,15 +195,7 @@ public class CelestialMapper extends AppFrame
                     Configuration.setValue(AVKey.INITIAL_PITCH, 80);
                 } else if (stereo && flat)
                 {
-                    //without this else if loop, the canvas glitches
-//                    Configuration.setValue(AVKey.GLOBE_CLASS_NAME, "gov.nasa.worldwind.globes.Earth");
-//                    System.setProperty("gov.nasa.worldwind.stereo.mode", "redblue");
-//                    //  Configure the initial view parameters so that the balloons are immediately visible.
-//                    Configuration.setValue(AVKey.INITIAL_LATITUDE, 20);
-//                    Configuration.setValue(AVKey.INITIAL_LONGITUDE, 30);
-//                    Configuration.setValue(AVKey.INITIAL_ALTITUDE, 10e4);
-//                    Configuration.setValue(AVKey.INITIAL_HEADING, 500);
-//                    Configuration.setValue(AVKey.INITIAL_PITCH, 80);
+                    //without this else if loop, the canvas glitches               
                 } else {
                     System.setProperty("gov.nasa.worldwind.stereo.mode", "");
                     Configuration.setValue(AVKey.INITIAL_LATITUDE, 0);
@@ -234,12 +223,7 @@ public class CelestialMapper extends AppFrame
                 }
                 restart();
             });
-            view.add(flatGlobe);
-            
-//            //====== "Satellite" =============
-//            orbitalSatellite = new SatelliteObject(this.getWwd());
-//            view.add(orbitalSatellite);
-            
+            view.add(flatGlobe);           
             
             //======== "Reset" =========
             reset = new JMenuItem("Reset");

--- a/src/gov/nasa/cms/features/ApolloAnnotations.java
+++ b/src/gov/nasa/cms/features/ApolloAnnotations.java
@@ -46,13 +46,6 @@ public class ApolloAnnotations extends JCheckBoxMenuItem
     private Color savedBorderColor;
     private BufferedImage savedImage;
     private Annotation lastPickedObject;
-    private LayerList layerList;
-    private Layer apollo11;
-    private Layer apollo12;
-    private Layer apollo14;
-    private Layer apollo15;
-    private Layer apollo16;
-    private Layer apollo17;
     
     private final static PowerOfTwoPaddedImage APOLLO11
             = PowerOfTwoPaddedImage.fromPath("images/Apollo11.jpg");
@@ -135,7 +128,6 @@ public class ApolloAnnotations extends JCheckBoxMenuItem
         spAttr.setFont(Font.decode("Arial-BOLDITALIC-12"));
         spAttr.setTextColor(Color.YELLOW);
         spAttr.setTextAlign(AVKey.CENTER);
-        //spAttr.setFrameShape(AVKey.SHAPE_NONE);
         spAttr.setDrawOffset(new Point(0, 5));
         spAttr.setEffect(AVKey.TEXT_EFFECT_OUTLINE);
         layer.addAnnotation(new GlobeAnnotation("Apollo 11",

--- a/src/gov/nasa/cms/features/MoonElevationModel.java
+++ b/src/gov/nasa/cms/features/MoonElevationModel.java
@@ -24,7 +24,7 @@ import java.io.File;
 public class MoonElevationModel extends CelestialMapper {
 
     // The data to import.
-    protected static final String ELEVATIONS_PATH = "cms-data/lunar-rescale.tif";
+    protected static final String ELEVATIONS_PATH = "cms-data/lunar-dem.tif";
     private WorldWindow wwd;
 
     public MoonElevationModel(WorldWindow wwd) {

--- a/src/gov/nasa/cms/features/MoonElevationModel.java
+++ b/src/gov/nasa/cms/features/MoonElevationModel.java
@@ -24,7 +24,7 @@ import java.io.File;
 public class MoonElevationModel extends CelestialMapper {
 
     // The data to import.
-    protected static final String ELEVATIONS_PATH = "cms-data/lunar-dem.tif";
+    protected static final String ELEVATIONS_PATH = "cms-data/lunar-rescale.tif";
     private WorldWindow wwd;
 
     public MoonElevationModel(WorldWindow wwd) {
@@ -32,8 +32,7 @@ public class MoonElevationModel extends CelestialMapper {
         Thread t = new Thread(new Runnable() {
             public void run() {
                 try {
-                    // Download the data and save it in a temp file.
-                    //File sourceFile = ExampleUtil.saveResourceToTempFile(ELEVATIONS_PATH, ".tif");
+                    // Download the data and save it in a File
                     File sourceFile = new File(ELEVATIONS_PATH);
                     // Create a local elevation model from the data.
                     LocalElevationModel elevationModel = new LocalElevationModel();
@@ -44,9 +43,7 @@ public class MoonElevationModel extends CelestialMapper {
 
                             // Get the WorldWindow's current elevation model.
                             wwd.getModel().getGlobe().setElevationModel(elevationModel);
-                    
-                            // Set the view to look at the imported elevations
-
+                            
                             // Set the view to look at the imported elevations, although they might be hard to detect. To
                             // make them easier to detect, replace the globe's CompoundElevationModel with the new elevation
                             // model rather than adding it.


### PR DESCRIPTION
### Description of the Change
Changed MoonElevationModel class to load a rescaled DEM of the LRO elevation data. 
Cleaned up comments.

### Why Should This Be In Core?
Scaled elevation provides more accurate values for elevation (about 2 times as much). Features for measurement, terrain profiler, and metrics will be more reflective of the lunar surface.

### Benefits
Higher accuracy profiling and elevation metrics for users to analyze the lunar surface.

### Potential Drawbacks
The code used to rescale the model takes the input DEM and divides it in half. This works because the values produced by re-projecting were off by about two times as much to the original model. This should only be used as a temporary solution until we can utilize a supported Moon CRS in CMS because it isn't very reliable.

### Applicable Issues