### PR TITLE
CMS Configuration Files

### DIFF
--- a/src/config/worldwind.layers.xml
+++ b/src/config/worldwind.layers.xml
@@ -16,9 +16,8 @@
         <Property name="Name" value="Stars"/>
     </Layer>
 
-    <Layer href="cms-data/layers/LROWACGlobalMosaic.xml" actuate="onLoad"/>
     <Layer href="cms-data/layers/LOLAColor.xml" actuate="onRequest"/>
-    <Layer href="cms-data/layers/LOLASteel.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/LOLASteel.xml" actuate="onLoad"/>
     <Layer href="cms-data/layers/LOLAGrayscale.xml" actuate="onRequest"/>
     <Layer href="cms-data/layers/KaguyaTCOrtho.xml" actuate="onRequest"/>
     <Layer href="cms-data/layers/LOLAKaguyaTCShadedRelief.xml" actuate="onRequest"/>

--- a/src/gov/nasa/cms/CelestialMapper.java
+++ b/src/gov/nasa/cms/CelestialMapper.java
@@ -11,7 +11,6 @@ import gov.nasa.cms.features.CMSProfile;
 import gov.nasa.cms.features.LayerManagerLayer;
 import gov.nasa.cms.features.MeasureDialog;
 import gov.nasa.cms.features.MoonElevationModel;
-import gov.nasa.cms.features.SatelliteObject;
 import gov.nasa.worldwind.Configuration;
 import gov.nasa.worldwind.util.measure.MeasureTool;
 import gov.nasa.worldwind.layers.*;
@@ -20,7 +19,7 @@ import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.geom.Angle;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.geom.Sector;
-import gov.nasa.worldwind.globes.EarthFlat;
+import gov.nasa.worldwind.globes.MoonFlat;
 import gov.nasa.worldwind.render.ScreenImage;
 import gov.nasa.worldwind.util.Logging;
 import java.awt.Point;
@@ -218,7 +217,7 @@ public class CelestialMapper extends AppFrame
                 flat = !flat;
                 if (flat)
                 {
-                    Configuration.setValue(AVKey.GLOBE_CLASS_NAME, EarthFlat.class.getName());
+                    Configuration.setValue(AVKey.GLOBE_CLASS_NAME, MoonFlat.class.getName());
                 } else 
                 {
                     Configuration.setValue(AVKey.GLOBE_CLASS_NAME, "gov.nasa.worldwind.globes.Earth");

--- a/src/gov/nasa/cms/CelestialMappingSystem.java
+++ b/src/gov/nasa/cms/CelestialMappingSystem.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package gov.nasa.cms;
 
 import gov.nasa.worldwind.Configuration;
@@ -17,7 +12,10 @@ public class CelestialMappingSystem
     public static final String APP_NAME = "Celestial Mapping System";
      
     public static void main(String[] args) 
-    {               
+    {  
+        // Set the WorldWind Configuration document to be overriden by CMS properties
+       System.setProperty("gov.nasa.worldwind.app.config.document", "gov/nasa/cms/config/cmsConfiguration.xml");
+                
         if (Configuration.isMacOS()) {
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", APP_NAME);
         }
@@ -30,8 +28,6 @@ public class CelestialMappingSystem
             java.awt.EventQueue.invokeLater(() -> {
                 cms.setVisible(true);
             });
-
-//            return frame;
         } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);

--- a/src/gov/nasa/cms/CelestialMappingSystem.java
+++ b/src/gov/nasa/cms/CelestialMappingSystem.java
@@ -10,12 +10,12 @@ import javax.swing.JFrame;
 public class CelestialMappingSystem 
 {   
     public static final String APP_NAME = "Celestial Mapping System";
-     
+
     public static void main(String[] args) 
     {  
         // Set the WorldWind Configuration document to be overriden by CMS properties
-       System.setProperty("gov.nasa.worldwind.app.config.document", "gov/nasa/cms/config/cmsConfiguration.xml");
-                
+        System.setProperty("gov.nasa.worldwind.app.config.document", "gov/nasa/cms/config/cmsConfiguration.xml");    
+       
         if (Configuration.isMacOS()) {
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", APP_NAME);
         }

--- a/src/gov/nasa/cms/config/cmsConfiguration.xml
+++ b/src/gov/nasa/cms/config/cmsConfiguration.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2012 United States Government as represented by the Administrator of the
+  ~ National Aeronautics and Space Administration.
+  ~ All Rights Reserved.
+  -->
+
+<!--$Id: worldwind.xml 2348 2014-09-25 23:35:46Z dcollins $-->
+<!--Default WorldWind configuration values-->
+<!--Any of these can be overridden by specifying an application configuration document-->
+<!--An alternate document to this one can also be specified-->
+<!--See the javadoc for the Configuration class for details-->
+<WorldWindConfiguration version="1">
+    <!--The initial layer list can be embedded here or linked as below. To change the set of initial layers,-->
+    <!--modify the file identified by the href or replace the link with your own-->
+    <LayerList href="gov/nasa/cms/config/cmsLayers.xml"/>
+    <!--Most configuration information is defined in attribute-value pairs-->
+    <Property name="gov.nasa.worldwind.avkey.ModelClassName" value="gov.nasa.worldwind.BasicModel"/>
+    <Property name="gov.nasa.worldwind.avkey.GlobeClassName"
+              value="gov.nasa.worldwind.globes.Earth"/>
+    <Property name="gov.nasa.worldwind.avkey.EarthElevationModelConfigFile"
+              value="gov/nasa/cms/config/Moon/EarthElevations2.xml"/>
+    <Property name="gov.nasa.worldwind.globes.GeographicProjectionClassName"
+              value="gov.nasa.worldwind.globes.projections.ProjectionEquirectangular"/>
+    <Property name="gov.nasa.worldwind.avkey.InitialLatitude" value="38"/>
+    <Property name="gov.nasa.worldwind.avkey.InitialAltitude" value="19.07e6"/>
+    <Property name="gov.nasa.worldwind.avkey.ViewClassName" value="gov.nasa.worldwind.view.orbit.BasicOrbitView"/>
+    <Property name="gov.nasa.worldwind.avkey.ViewInputHandlerClassName"
+              value="gov.nasa.worldwind.view.orbit.OrbitViewInputHandler"/>
+    <Property name="gov.nasa.worldwind.avkey.InputHandlerClassName" value="gov.nasa.worldwind.awt.AWTInputHandler"/>
+    <Property name="gov.nasa.worldwind.avkey.LoggerName" value="gov.nasa.worldwind"/>
+    <Property name="gov.nasa.worldwind.avkey.WorldWindowClassName"
+              value="gov.nasa.worldwind.WorldWindowGLAutoDrawable"/>
+    <Property name="gov.nasa.worldwind.avkey.ElevationModelFactory"
+              value="gov.nasa.worldwind.terrain.BasicElevationModelFactory"/>
+    <Property name="gov.nasa.worldwind.avkey.LayerFactory" value="gov.nasa.worldwind.layers.BasicLayerFactory"/>
+    <Property name="gov.nasa.worldwind.avkey.ShapefileLayerFactory"
+              value="gov.nasa.worldwind.formats.shapefile.ShapefileLayerFactory"/>
+    <Property name="gov.nasa.worldwind.avkey.WebViewFactory"
+              value="gov.nasa.worldwind.util.webview.BasicWebViewFactory"/>
+    <Property name="gov.nasa.worldwind.avkey.TessellatorClassName"
+              value="gov.nasa.worldwind.terrain.RectangularTessellator"/>
+    <Property name="gov.nasa.worldwind.avkey.MemoryCacheSetClassName"
+              value="gov.nasa.worldwind.cache.BasicMemoryCacheSet"/>
+    <Property name="gov.nasa.worldwind.avkey.SessionCacheClassName" value="gov.nasa.worldwind.cache.BasicSessionCache"/>
+    <Property name="gov.nasa.worldwind.avkey.RetrievalServiceClassName"
+              value="gov.nasa.worldwind.retrieve.BasicRetrievalService"/>
+    <Property name="gov.nasa.worldwind.avkey.SceneControllerClassName"
+              value="gov.nasa.worldwind.StereoOptionSceneController"/>
+    <Property name="gov.nasa.worldwind.avkey.NetworkStatusClassName"
+              value="gov.nasa.worldwind.util.BasicNetworkStatus"/>
+    <Property name="gov.nasa.worldwind.render.PointPlacemarkAttributes.DefaultImagePath"
+              value="images/pushpins/plain-yellow.png"/>
+    <Property name="gov.nasa.worldwind.render.PointPlacemarkAttributes.DefaultLabelFont"
+              value="Arial-BOLD-14"/>
+    <!-- The following lists the sites to test for public network access. Specify an empty string, "", for no sites.-->
+    <!-- Don't specify the property at all to use the default list. -->
+    <Property name="gov.nasa.worldwind.avkey.NetworkStatusTestSites"
+              value="www.nasa.gov, worldwind.arc.nasa.gov, google.com, microsoft.com, yahoo.com"/>
+    <Property name="gov.nasa.worldwind.avkey.TaskServiceClassName" value="gov.nasa.worldwind.util.ThreadedTaskService"/>
+    <Property name="gov.nasa.worldwind.avkey.DataFileStoreClassName"
+              value="gov.nasa.worldwind.cache.BasicDataFileStore"/>
+    <Property name="gov.nasa.worldwind.avkey.DataRasterReaderFactoryClassName"
+              value="gov.nasa.worldwind.data.BasicDataRasterReaderFactory"/>
+    <Property name="gov.nasa.worldwind.avkey.DataFileStoreConfigurationFileName" value="config/DataFileStore.xml"/>
+    <Property name="gov.nasa.worldwind.avkey.WorldMapImagePath" value="images/earth-map-512x256.dds"/>
+    <Property name="gov.nasa.worldwind.StarsLayer.StarsFileName" value="config/Hipparcos_Stars_Mag6x5044.dat"/>
+    <!--The following are tuning parameters for various WorldWind internals-->
+    <Property name="gov.nasa.worldwind.avkey.RetrievalPoolSize" value="4"/>
+    <Property name="gov.nasa.worldwind.avkey.RetrievalQueueSize" value="200"/>
+    <Property name="gov.nasa.worldwind.avkey.RetrievalStaleRequestLimit" value="9000"/>
+    <Property name="gov.nasa.worldwind.avkey.TaskPoolSize" value="4"/>
+    <Property name="gov.nasa.worldwind.avkey.TaskQueueSize" value="20"/>
+    <Property name="gov.nasa.worldwind.avkey.ScheduledTaskPoolSize" value="1"/>
+    <Property name="gov.nasa.worldwind.avkey.VerticalExaggeration" value="1"/>
+    <Property name="gov.nasa.worldwind.avkey.URLConnectTimeout" value="8000"/>
+    <Property name="gov.nasa.worldwind.avkey.URLReadTimeout" value="10000"/>
+    <Property name="gov.nasa.worldwind.avkey.TextureCacheSize" value="500000000"/>
+    <Property name="gov.nasa.worldwind.avkey.ElevationTileCacheSize" value="20000000"/>
+    <Property name="gov.nasa.worldwind.avkey.ElevationExtremesLookupCacheSize" value="20000000"/>
+    <Property name="gov.nasa.worldwind.avkey.SectorGeometryCacheSize" value="10000000"/>
+    <Property name="gov.nasa.worldwind.avkey.TextureTileCacheSize" value="10000000"/>
+    <Property name="gov.nasa.worldwind.avkey.PlacenameLayerCacheSize" value="4000000"/>
+    <Property name="gov.nasa.worldwind.avkey.AirspaceGeometryCacheSize" value="32000000"/>
+    <Property name="gov.nasa.worldwind.avkey.VBOUsage" value="true"/>
+    <Property name="gov.nasa.worldwind.avkey.VBOThreshold" value="30"/>
+    <Property name="gov.nasa.worldwind.avkey.OfflineMode" value="false"/>
+    <Property name="gov.nasa.worldwind.avkey.RectangularTessellatorMaxLevel" value="30"/>
+    <Property name="gov.nasa.worldwind.StereoFocusAngle" value="1.6"/>
+    <Property name="gov.nasa.worldwind.avkey.ForceRedrawOnMousePressed" value="f"/>
+    <!-- Here's one way to specify proxy settings -->
+    <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyHost" value="100.215.10.20"/>-->
+    <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyPort" value="8080"/>-->
+    <!--<Property name="gov.nasa.worldwind.avkey.UrlProxyType" value="Proxy.Type.Http"/>-->
+
+    <!-- Location of icons for MIL-STD-2525C symbol set. This can be a URL to a web server, to a local zip or jar archive.
+         See https://goworldwind.org/developers-guide/symbology/tactical-symbols/#offline-use for more information on how
+         to configure a local symbol repository.
+         Examples: http://myserver.com/milstd2525/   (web server)
+                   jar:file:milstd2525-symbols.zip!  (local zip archive)  -->
+    <Property name="gov.nasa.worldwind.avkey.MilStd2525IconRetrieverPath"
+              value="https://worldwind.arc.nasa.gov/milstd2525c/rev1/"/>
+</WorldWindConfiguration>

--- a/src/gov/nasa/cms/config/cmsConfiguration.xml
+++ b/src/gov/nasa/cms/config/cmsConfiguration.xml
@@ -5,21 +5,18 @@
   ~ All Rights Reserved.
   -->
 
-<!--$Id: worldwind.xml 2348 2014-09-25 23:35:46Z dcollins $-->
-<!--Default WorldWind configuration values-->
-<!--Any of these can be overridden by specifying an application configuration document-->
-<!--An alternate document to this one can also be specified-->
+<!--Default configuration values for CelestialMappingSystem.javas-->
 <!--See the javadoc for the Configuration class for details-->
 <WorldWindConfiguration version="1">
-    <!--The initial layer list can be embedded here or linked as below. To change the set of initial layers,-->
-    <!--modify the file identified by the href or replace the link with your own-->
+    <!-- CMS LayerList -->
     <LayerList href="gov/nasa/cms/config/cmsLayers.xml"/>
-    <!--Most configuration information is defined in attribute-value pairs-->
     <Property name="gov.nasa.worldwind.avkey.ModelClassName" value="gov.nasa.worldwind.BasicModel"/>
+    <!-- Lunar Globe -->
     <Property name="gov.nasa.worldwind.avkey.GlobeClassName"
-              value="gov.nasa.worldwind.globes.Earth"/>
+              value="gov.nasa.worldwind.globes.Moon"/>
+    <!-- Elevation -->
     <Property name="gov.nasa.worldwind.avkey.EarthElevationModelConfigFile"
-              value="gov/nasa/cms/config/Moon/EarthElevations2.xml"/>
+              value="gov/nasa/cms/config/Moon/EarthElevations2.xml"/> 
     <Property name="gov.nasa.worldwind.globes.GeographicProjectionClassName"
               value="gov.nasa.worldwind.globes.projections.ProjectionEquirectangular"/>
     <Property name="gov.nasa.worldwind.avkey.InitialLatitude" value="38"/>

--- a/src/gov/nasa/cms/config/cmsLayers.xml
+++ b/src/gov/nasa/cms/config/cmsLayers.xml
@@ -5,17 +5,10 @@
   ~ All Rights Reserved.
   -->
 
-<!--$Id: worldwind.layers.xml 2256 2014-08-22 17:46:18Z tgaskins $-->
-<!--This document specifies the initial layers to load in WorldWind-->
-<!--This list can be overridden by specifying an alternate list in worldwind.xml, or by specifying an-->
-<!--alternate configuration document-->
-<!--See the javadoc for the Configuration class for details-->
+<!-- This document specifies the initial layers to load upon running CelestialMappingSystem.java -->
 <LayerList>
-    <Layer className="gov.nasa.worldwind.layers.StarsLayer">
-        <!--Individual properties can be specified within Layer entries, like this:-->
-        <Property name="Name" value="Stars"/>
-    </Layer>
 
+ <!-- Global Basemaps -->   
     <Layer href="cms-data/layers/LROWACGlobalMosaic.xml" actuate="onLoad"/>
     <Layer href="cms-data/layers/LOLAColor.xml" actuate="onRequest"/>
     <Layer href="cms-data/layers/LOLASteel.xml" actuate="onRequest"/>
@@ -26,7 +19,8 @@
     <Layer href="cms-data/layers/ClementineLunarOrbiterHybrid.xml" actuate="onRequest"/>
     <Layer href="cms-data/layers/LunarOrbiterGlobalMosaic.xml" actuate="onRequest"/>
     <Layer href="cms-data/layers/UnifiedGeologicMapOfTheMoon.xml" actuate="onRequest"/>
-                 
+          
+<!-- Class Layers -->       
     <Layer className="gov.nasa.worldwind.layers.LatLonGraticuleLayer" actuate="onRequest">
         <Property name="Name" value="Lat-Lon Graticule"/>
     </Layer>/>
@@ -34,4 +28,7 @@
         <Property name="Name" value="GARS Graticule"/>
     </Layer>/>
     <Layer className="gov.nasa.worldwind.layers.ScalebarLayer"/>
+    <Layer className="gov.nasa.worldwind.layers.StarsLayer">
+        <Property name="Name" value="Stars"/>
+    </Layer>       
 </LayerList>

--- a/src/gov/nasa/cms/config/cmsLayers.xml
+++ b/src/gov/nasa/cms/config/cmsLayers.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2012 United States Government as represented by the Administrator of the
+  ~ National Aeronautics and Space Administration.
+  ~ All Rights Reserved.
+  -->
+
+<!--$Id: worldwind.layers.xml 2256 2014-08-22 17:46:18Z tgaskins $-->
+<!--This document specifies the initial layers to load in WorldWind-->
+<!--This list can be overridden by specifying an alternate list in worldwind.xml, or by specifying an-->
+<!--alternate configuration document-->
+<!--See the javadoc for the Configuration class for details-->
+<LayerList>
+    <Layer className="gov.nasa.worldwind.layers.StarsLayer">
+        <!--Individual properties can be specified within Layer entries, like this:-->
+        <Property name="Name" value="Stars"/>
+    </Layer>
+
+    <Layer href="cms-data/layers/LROWACGlobalMosaic.xml" actuate="onLoad"/>
+    <Layer href="cms-data/layers/LOLAColor.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/LOLASteel.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/LOLAGrayscale.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/KaguyaTCOrtho.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/LOLAKaguyaTCShadedRelief.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/ClementineBasemapV2.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/ClementineLunarOrbiterHybrid.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/LunarOrbiterGlobalMosaic.xml" actuate="onRequest"/>
+    <Layer href="cms-data/layers/UnifiedGeologicMapOfTheMoon.xml" actuate="onRequest"/>
+                 
+    <Layer className="gov.nasa.worldwind.layers.LatLonGraticuleLayer" actuate="onRequest">
+        <Property name="Name" value="Lat-Lon Graticule"/>
+    </Layer>/>
+    <Layer className="gov.nasa.worldwind.layers.GARSGraticuleLayer" actuate="onRequest">
+        <Property name="Name" value="GARS Graticule"/>
+    </Layer>/>
+    <Layer className="gov.nasa.worldwind.layers.ScalebarLayer"/>
+</LayerList>

--- a/src/gov/nasa/worldwind/globes/Earth.java
+++ b/src/gov/nasa/worldwind/globes/Earth.java
@@ -17,19 +17,18 @@ import gov.nasa.worldwind.avlist.AVKey;
 
 public class Earth extends EllipsoidalGlobe
 {
-    public static final double WGS84_EQUATORIAL_RADIUS = 1737400; // ellipsoid equatorial getRadius, in meters
-    public static final double WGS84_POLAR_RADIUS = 1737400; // ellipsoid polar getRadius, in meters
-    public static final double WGS84_ES = 0.0; // eccentricity squared, semi-major axis
+    public static final double WGS84_EQUATORIAL_RADIUS = 6378137.0; // ellipsoid equatorial getRadius, in meters
+    public static final double WGS84_POLAR_RADIUS = 6356752.3; // ellipsoid polar getRadius, in meters
+    public static final double WGS84_ES = 0.00669437999013; // eccentricity squared, semi-major axis
 
-
-    public static final double ELEVATION_MIN = -9000; // Depth of Antoniadi Crater
-    public static final double ELEVATION_MAX = 10700; // Height of Selean Summit.
+    public static final double ELEVATION_MIN = -11000d; // Depth of Marianas trench
+    public static final double ELEVATION_MAX = 8500d; // Height of Mt. Everest.
 
     public Earth()
     {
         super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
-            EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
-                "cms-data/layers/EarthElevations2.xml"));
+            EllipsoidalGlobe.makeElevationModel(AVKey.EARTH_ELEVATION_MODEL_CONFIG_FILE,
+                "config/Earth/EarthElevations2.xml"));
     }
 
     public String toString()

--- a/src/gov/nasa/worldwind/globes/EarthFlat.java
+++ b/src/gov/nasa/worldwind/globes/EarthFlat.java
@@ -17,15 +17,18 @@ import gov.nasa.worldwind.avlist.AVKey;
 
 public class EarthFlat extends FlatGlobe
 {
-    public static final double WGS84_EQUATORIAL_RADIUS = 1737400; // ellipsoid equatorial getRadius, in meters
-    public static final double WGS84_POLAR_RADIUS = 1737400; // ellipsoid polar getRadius, in meters
-    public static final double WGS84_ES = 0.0; // eccentricity squared, semi-major axis
+    public static final double WGS84_EQUATORIAL_RADIUS = 6378137.0; // ellipsoid equatorial getRadius, in meters
+    public static final double WGS84_POLAR_RADIUS = 6356752.3; // ellipsoid polar getRadius, in meters
+    public static final double WGS84_ES = 0.00669437999013; // eccentricity squared, semi-major axis
+
+    public static final double ELEVATION_MIN = -11000d; // Depth of Marianas trench
+    public static final double ELEVATION_MAX = 8500d; // Height of Mt. Everest.
 
     public EarthFlat()
     {
         super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
-            EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
-                "cms-data/layers/EarthElevations2.xml"));
+            EllipsoidalGlobe.makeElevationModel(AVKey.EARTH_ELEVATION_MODEL_CONFIG_FILE,
+                "config/Earth/EarthElevations2.xml"));
     }
 
     public String toString()

--- a/src/gov/nasa/worldwind/globes/Moon.java
+++ b/src/gov/nasa/worldwind/globes/Moon.java
@@ -1,0 +1,35 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package gov.nasa.worldwind.globes;
+
+import gov.nasa.worldwind.avlist.AVKey;
+
+/**
+ *
+ * @author kjdickin
+ */
+public class Moon extends EllipsoidalGlobe
+{
+    public static final double WGS84_EQUATORIAL_RADIUS = 1737400; // ellipsoid equatorial getRadius, in meters
+    public static final double WGS84_POLAR_RADIUS = 1737400; // ellipsoid polar getRadius, in meters
+    public static final double WGS84_ES = 0.0; // eccentricity squared, semi-major axis
+
+
+    public static final double ELEVATION_MIN = -9000; // Depth of Antoniadi Crater
+    public static final double ELEVATION_MAX = 10700; // Height of Selean Summit.
+
+    public Moon()
+    {
+        super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
+            EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
+                "cms-data/layers/EarthElevations2.xml"));
+    }
+
+    public String toString()
+    {
+        return "Moon";
+    }
+}

--- a/src/gov/nasa/worldwind/globes/MoonFlat.java
+++ b/src/gov/nasa/worldwind/globes/MoonFlat.java
@@ -1,0 +1,31 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package gov.nasa.worldwind.globes;
+
+import gov.nasa.worldwind.avlist.AVKey;
+
+/**
+ *
+ * @author kjdickin
+ */
+public class MoonFlat extends FlatGlobe
+{
+    public static final double WGS84_EQUATORIAL_RADIUS = 1737400; // ellipsoid equatorial getRadius, in meters
+    public static final double WGS84_POLAR_RADIUS = 1737400; // ellipsoid polar getRadius, in meters
+    public static final double WGS84_ES = 0.0; // eccentricity squared, semi-major axis
+
+    public MoonFlat()
+    {
+        super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
+            EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
+                "cms-data/layers/EarthElevations2.xml"));
+    }
+
+    public String toString()
+    {
+        return "Flat Moon";
+    }
+}

--- a/src/gov/nasa/worldwindx/applications/worldwindow/config/InitialLayerConfiguration.xml
+++ b/src/gov/nasa/worldwindx/applications/worldwindow/config/InitialLayerConfiguration.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+F<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (C) 2012 United States Government as represented by the Administrator of the
   ~ National Aeronautics and Space Administration.


### PR DESCRIPTION
### Description of the Change
- Created configuration files specific to CelestialMappingSystem.java in cms/config, these override worldwind.xml and worldwind.layers.xml configuration files
- Created Moon and MoonFlat globes. Refactored to utilize those classes instead of the Earth globes with lunar parameters. Earth globes are back to Earth parameters for possible testing purposes.

### Why Should This Be In Core?
- Differentiate between WorldWind and CelestialMappingSystem configurations.
- Clearer purpose of lunar app by renaming globes. When we add Mars, Titan, etc, those can be added to the same globes folder.

### Benefits
- Once the server is set up we will be implementing more datasets. Creating configuration files specific to CelestialMappingSystem allows for a more organized structure and layers can easily be added to cmsLayers.xml.
- Specify properties specific to celestial bodies in cmsConfiguration.xml, such as altitude and elevation model.

### Potential Drawbacks
- Developers not knowing where to look for files, so should be clearly documented.

### Applicable Issues