### PR TITLE
High Resolution Server Layers

### DIFF
--- a/cms-data/layers/MoonElevationModel.xml
+++ b/cms-data/layers/MoonElevationModel.xml
@@ -5,26 +5,24 @@
   ~ All Rights Reserved.
   -->
 
-<!--$Id: EarthElevations2.xml 3087 2015-05-13 20:34:41Z dcollins $-->
-<ElevationModel version="1" modelType="Compound">
+<!-- Provides global elevation for the lunar surface from the LRO LOLA DEM at 118m/px: https://astrogeology.usgs.gov/search/details/Moon/LRO/LOLA/Lunar_LRO_LOLA_Global_LDEM_118m_Mar2014/cub $-->
+
+<ElevationModel version="1">
     <ElevationModel version="1">
-        <DisplayName>USA 10m, World 30m, Ocean 900m</DisplayName>
+        <DisplayName>LRO Elevation</DisplayName>
         <Service serviceName="OGC:WMS" version="1.3">
-            <GetCapabilitiesURL>https://worldwind26.arc.nasa.gov/elev</GetCapabilitiesURL>
-            <GetMapURL>https://worldwind26.arc.nasa.gov/elev</GetMapURL>
-            <LayerNames>NASA_SRTM30_900m_Tiled,aster_v2,USGS-NED</LayerNames>
+            <GetCapabilitiesURL>https://celestial.arc.nasa.gov/cgi-bin/mapserv?map=/data/elev/lro.map</GetCapabilitiesURL>
+            <GetMapURL>https://celestial.arc.nasa.gov/cgi-bin/mapserv?map=/data/elev/lro.map</GetMapURL>
+            <LayerNames>lro_elevations_layer</LayerNames>
         </Service>
         <RetrievePropertiesFromService>true</RetrievePropertiesFromService>
         <!-- day month year hours:minutes:seconds timezone -->
         <LastUpdate>16 01 2014 20:00:00 GMT</LastUpdate>
-        <DataCacheName>Earth/EarthElevations2</DataCacheName>
+        <DataCacheName>Moon/LROElevation</DataCacheName>
         <ImageFormat>application/bil16</ImageFormat>
         <DataType type="Int16" byteOrder="LittleEndian"/>
         <DataDetailHint>0.20</DataDetailHint>
         <FormatSuffix>.bil</FormatSuffix>
-        <ExtremeElevations min="-14380" max="8850">
-            <FileName>config/SRTM30Plus_ExtremeElevations_5.bil</FileName>
-        </ExtremeElevations>
         <NumLevels count="12" numEmpty="0"/>
         <TileOrigin>
             <LatLon units="degrees" latitude="-90" longitude="-180"/>

--- a/cms-data/layers/UnifiedGeologicMapOfTheMoon.xml
+++ b/cms-data/layers/UnifiedGeologicMapOfTheMoon.xml
@@ -4,18 +4,17 @@
   ~ National Aeronautics and Space Administration.
   ~ All Rights Reserved.
   -->
-
-<!-- These maps are a series of geologic maps that cover the entire Moon at a scale of 1:5,000,000 originally created in the 1970's - 2013 version -->
+  
+<!-- These maps are a series of geologic maps that cover the entire Moon at a scale of 1:5,000,000 originally created in the 1970's - 2020 version -->
 <Layer version="1" layerType="TiledImageLayer">
     <DisplayName>Unified Geologic Map of The Moon</DisplayName>
     <Service serviceName="OGC:WMS" version="1.3">
-        <GetCapabilitiesURL>https://gis.usgs.gov/sciencebase2/services/Catalog/5e18e09ae4b0ecf25c5b04bd/MapServer/WmsServer</GetCapabilitiesURL>
-        <GetMapURL>https://gis.usgs.gov/sciencebase2/services/Catalog/5e18e09ae4b0ecf25c5b04bd/MapServer/WmsServer</GetMapURL>
-        <LayerNames>0,2</LayerNames>
-        <StyleNames>default,default</StyleNames>
+        <GetCapabilitiesURL>https://celestial.arc.nasa.gov/cgi-bin/mapserv?map=/data/geologic/UnifiedGeologicMapOfTheMoon.map</GetCapabilitiesURL>
+        <GetMapURL>https://celestial.arc.nasa.gov/cgi-bin/mapserv?map=/data/geologic/UnifiedGeologicMapOfTheMoon.map</GetMapURL>
+        <LayerNames>unified_geologic_map_of_the_moon_layer</LayerNames>
     </Service>
     <RetrievePropertiesFromService>true</RetrievePropertiesFromService>
-    <DataCacheName>Moon/UnifiedGeologicMapOfTheMoon</DataCacheName> 
+    <DataCacheName>Moon/Geologic</DataCacheName> 
     <ImageFormat>image/jpeg</ImageFormat>
     <AvailableImageFormats>
         <ImageFormat>image/jpeg</ImageFormat>
@@ -48,7 +47,6 @@
             <Time units="milliseconds" value="30000"/>
         </ReadTimeout>
     </RetrievalTimeouts>
-    <!-- The following lines are included just to show how to set the values to other than their defaults -->
     <MaxAbsentTileAttempts>2</MaxAbsentTileAttempts>
     <MinAbsentTileCheckInterval>1000</MinAbsentTileCheckInterval>
 </Layer>

--- a/src/gov/nasa/worldwind/globes/Moon.java
+++ b/src/gov/nasa/worldwind/globes/Moon.java
@@ -25,7 +25,7 @@ public class Moon extends EllipsoidalGlobe
     {
         super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
             EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
-                "cms-data/layers/EarthElevations2.xml"));
+                "cms-data/layers/MoonElevationModel.xml"));
     }
 
     public String toString()

--- a/src/gov/nasa/worldwind/globes/MoonFlat.java
+++ b/src/gov/nasa/worldwind/globes/MoonFlat.java
@@ -21,7 +21,7 @@ public class MoonFlat extends FlatGlobe
     {
         super(WGS84_EQUATORIAL_RADIUS, WGS84_POLAR_RADIUS, WGS84_ES,
             EllipsoidalGlobe.makeElevationModel(AVKey.MOON_ELEVATION_MODEL_CONFIG_FILE,
-                "cms-data/layers/EarthElevations2.xml"));
+                "cms-data/layers/MoonElevationModel.xml"));
     }
 
     public String toString()


### PR DESCRIPTION
### Description of the Change
Implemented Global Elevation data from LRO LOLA at 118mpp and Unified Geologic Map of The Moon from celestial server. Modified Moon and MoonFlat globes to point to new elevation model.

### Why Should This Be In Core?
More updated version of Unified Geologic of The Moon (2020 version compared to 2013), and elevation model with better accuracy.

### Benefits
More accurate measurements and elevation profiling. Unified Geologic Map of The Moon is a popularly requested map which will allow users to view the geologic features of the Moon.

### Potential Drawbacks
Elevation model has a small sector of the globe that isn't being rendered (this is the same with the local elevation model, however). Will need to find a solution using GDAL.

### Applicable Issues