### PR TITLE
Coordinates display layer

### DIFF
--- a/src/gov/nasa/cms/CelestialMapper.java
+++ b/src/gov/nasa/cms/CelestialMapper.java
@@ -6,7 +6,6 @@
 package gov.nasa.cms;
         
 import gov.nasa.cms.features.CMSPlaceNamesMenu;
-import gov.nasa.cms.features.*;
 import gov.nasa.cms.features.coordinates.*;
 import gov.nasa.cms.features.ApolloMenu;
 import gov.nasa.cms.features.ApolloDialog;
@@ -27,15 +26,12 @@ import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.globes.MoonFlat;
 import gov.nasa.worldwind.render.ScreenImage;
 import gov.nasa.worldwind.util.Logging;
-import gov.nasa.worldwindx.applications.worldwindow.util.WWOUnitsFormat;
 
 import java.awt.*;
 import javax.swing.*;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
-import java.net.*;
-import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
@@ -82,7 +78,7 @@ public class CelestialMapper extends AppFrame
     private ApolloDialog apolloDialog;
     private WorldMapLayer wml;
     private CoordinatesDisplay coordDisplay;
-    private WWOUnitsFormat unitsFormat;
+    private CMSWWOUnitsFormat unitsFormat;
 
     public void restart()
     {
@@ -108,9 +104,9 @@ public class CelestialMapper extends AppFrame
         this.toolBar.createToolbar();
 
         // create coordinates display layer
-        this.unitsFormat = new WWOUnitsFormat();
+        this.unitsFormat = new CMSWWOUnitsFormat();
         this.unitsFormat.setShowUTM(true);
-        this.unitsFormat.setShowWGS84(true);
+        this.unitsFormat.setShowWGS84(false);
         this.coordDisplay = new CoordinatesDisplay(this);
 
         // Import the lunar elevation data
@@ -619,7 +615,7 @@ public class CelestialMapper extends AppFrame
         return this.wml;
     }
 
-    public WWOUnitsFormat getUnits()
+    public CMSWWOUnitsFormat getUnits()
     {
         return this.unitsFormat;
     }

--- a/src/gov/nasa/cms/features/coordinates/CMSUnitsFormat.java
+++ b/src/gov/nasa/cms/features/coordinates/CMSUnitsFormat.java
@@ -1170,8 +1170,17 @@ public class CMSUnitsFormat extends AVListImpl
             symbol = CMSUnitsFormat.SYMBOL_FEET;
         }
 
+        // Updated return call that excludes the verticalExaggeration field.
+        // There isn't a placeholder for it in the setDefaultFormats() method anymore
+        // this.setFormat(FORMAT_TERRAIN_HEIGHT, " %,6d %s");
         return String.format(this.getLabel(LABEL_TERRAIN_HEIGHT) + getFormat(FORMAT_TERRAIN_HEIGHT),
             (int) Math.round((metersElevation / verticalExaggeration) * multiplier), symbol);
+
+        // The original return method that includes verticalExaggeration
+        // which matches the original setDefaultFormats() line
+        // this.setFormat(FORMAT_TERRAIN_HEIGHT, " (ve %3.1f): %,6d %s");
+//        return String.format(this.getLabel(LABEL_TERRAIN_HEIGHT) + getFormat(FORMAT_TERRAIN_HEIGHT), verticalExaggeration,
+//            (int) Math.round((metersElevation / verticalExaggeration) * multiplier), symbol);
     }
 
     /**

--- a/src/gov/nasa/cms/features/coordinates/CMSUnitsFormat.java
+++ b/src/gov/nasa/cms/features/coordinates/CMSUnitsFormat.java
@@ -1,0 +1,1252 @@
+/*
+ * Copyright (C) 2012 United States Government as represented by the Administrator of the
+ * National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ */
+
+package gov.nasa.cms.features.coordinates;
+
+import gov.nasa.worldwind.avlist.AVListImpl;
+import gov.nasa.worldwind.geom.*;
+import gov.nasa.worldwind.util.*;
+
+/**
+ * Consolidates the conversion, display and formatting of geographic units such as lengths in miles and areas in
+ * hectares. Applications configure a class instance to the desired units, labels and display formats, then simply
+ * retrieve display strings from the instance via one standard interface. All input values are in meters; the class
+ * performs the necessary conversions to the selected display units.
+ *
+ * @author gknorman
+ * @version $Id: CMSUnitsFormat.java 2301 2021-03-22 1:33:45Z gknorman $
+ * @see UnitsFormat
+ */
+public class CMSUnitsFormat extends AVListImpl
+{
+    // Keys identifying unit systems and units
+    public static final String IMPERIAL_SYSTEM = "gov.nasa.worldwind.units.ImperialSystem";
+    public static final String METRIC_SYSTEM = "gov.nasa.worldwind.units.MetricSystem";
+
+    public static final String METERS = "CMSUnitsFormat.Meters";
+    public static final String KILOMETERS = "CMSUnitsFormat.Kilometers";
+    public static final String MILES = "CMSUnitsFormat.Miles";
+    public static final String NAUTICAL_MILES = "CMSUnitsFormat.NauticalMiles";
+    public static final String YARDS = "CMSUnitsFormat.Yards";
+    public static final String FEET = "CMSUnitsFormat.Feet";
+
+    public static final String SQUARE_METERS = "CMSUnitsFormat.SquareMeters";
+    public static final String SQUARE_KILOMETERS = "CMSUnitsFormat.SquareKilometers";
+    public static final String SQUARE_MILES = "CMSUnitsFormat.SquareMiles";
+    public static final String HECTARE = "CMSUnitsFormat.Hectare";
+    public static final String ACRE = "CMSUnitsFormat.Acre";
+    public static final String SQUARE_YARDS = "CMSUnitsFormat.SquareYards";
+    public static final String SQUARE_FEET = "CMSUnitsFormat.SquareFeet";
+
+    // Keys identifying the symbol used when displaying the units
+    public static final String SYMBOL_METERS = "m";
+    public static final String SYMBOL_KILOMETERS = "km";
+    public static final String SYMBOL_MILES = "miles";
+    public static final String SYMBOL_NAUTICAL_MILES = "Nm";
+    public static final String SYMBOL_YARDS = "yd";
+    public static final String SYMBOL_FEET = "ft";
+
+    public static final String SYMBOL_SQUARE_METERS = "m\u00b2";
+    public static final String SYMBOL_SQUARE_KILOMETERS = "km\u00b2";
+    public static final String SYMBOL_SQUARE_MILES = "miles\u00b2";
+    public static final String SYMBOL_HECTARE = "ha";
+    public static final String SYMBOL_ACRE = "acres";
+    public static final String SYMBOL_SQUARE_YARDS = "yd\u00b2";
+    public static final String SYMBOL_SQUARE_FEET = "ft\u00b2";
+
+    // These keys identifying labels correspond to message catalog properties
+    public static final String LABEL_LATITUDE = "CMSUnitsFormat.LatitudeLabel";
+    public static final String LABEL_LONGITUDE = "CMSUnitsFormat.LongitudeLabel";
+    public static final String LABEL_LATLON_LAT = "CMSUnitsFormat.LatLonLatLabel";
+    public static final String LABEL_LATLON_LON = "CMSUnitsFormat.LatLonLonLabel";
+    public static final String LABEL_HEADING = "CMSUnitsFormat.HeadingLabel";
+    public static final String LABEL_EYE_ALTITUDE = "CMSUnitsFormat.EyeAltitudeLabel";
+    public static final String LABEL_PITCH = "CMSUnitsFormat.PitchLabel";
+    public static final String LABEL_UTM_ZONE = "CMSUnitsFormat.UTMZoneLabel";
+    public static final String LABEL_UTM_EASTING = "CMSUnitsFormat.UTMEastingLabel";
+    public static final String LABEL_UTM_NORTHING = "CMSUnitsFormat.UTMNorthingLabel";
+    public static final String LABEL_TERRAIN_HEIGHT = "CMSUnitsFormat.TerrainHeightLabel";
+    public static final String LABEL_DATUM = "CMSUnitsFormat.DatumLabel";
+
+    // Keys identifying display formats
+    public static final String FORMAT_LENGTH = "CMSUnitsFormat.FormatLength";
+    public static final String FORMAT_AREA = "CMSUnitsFormat.FormatArea";
+    public static final String FORMAT_PITCH = "CMSUnitsFormat.FormatPitch";
+    public static final String FORMAT_HEADING = "CMSUnitsFormat.FormatHeading";
+    public static final String FORMAT_UTM_NORTHING = "CMSUnitsFormat.FormatUTMNorthing";
+    public static final String FORMAT_UTM_EASTING = "CMSUnitsFormat.FormatUTMEasting";
+    public static final String FORMAT_EYE_ALTITUDE = "CMSUnitsFormat.FormatEyeAltitude";
+    public static final String FORMAT_DECIMAL_DEGREES = "CMSUnitsFormat.FormatDecimalDegrees";
+    public static final String FORMAT_TERRAIN_HEIGHT = "CMSUnitsFormat.FormatTerrainHeight";
+
+    protected static final String NL = "\n";
+
+    protected boolean showDMS = false;
+
+    protected String lengthUnits;
+    protected String lengthUnitsSymbol;
+    protected double lengthUnitsMultiplier; // factor to convert from meters to current units
+    protected String areaUnits;
+    protected String areaUnitsSymbol;
+    protected double areaUnitsMultiplier; // factor to convert from meters to current units
+    protected String altitudeUnits;
+    protected String altitudeUnitsSymbol;
+    protected double altitudeUnitsMultiplier; // factor to convert from meters to current units
+
+    /**
+     * Construct an instance that displays length in kilometers, area in square kilometers and angles in decimal
+     * degrees.
+     */
+    public CMSUnitsFormat()
+    {
+        this(CMSUnitsFormat.KILOMETERS, CMSUnitsFormat.SQUARE_KILOMETERS, false);
+    }
+
+    /**
+     * Constructs an instance that display length and area in specified units, and angles in decimal degrees.
+     *
+     * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
+     * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
+     *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
+     *
+     * @throws IllegalArgumentException if either <code>lengthUnits</code> or <code>areaUnits</code> is null.
+     */
+    public CMSUnitsFormat(String lengthUnits, String areaUnits)
+    {
+        this(lengthUnits, areaUnits, false);
+    }
+
+    /**
+     * Constructs an instance that display length and area in specified units, and angles in a specified format.
+     *
+     * @param lengthUnits the desired length units. Available length units are <code>METERS, KILOMETERS, MILES,
+     *                    NAUTICAL_MILES, YARDS</code> and <code>FEET</code>.
+     * @param areaUnits   the desired area units. Available area units are <code>SQUARE_METERS, SQUARE_KILOMETERS,
+     *                    HECTARE, ACRE, SQUARE_YARD</code> and <code>SQUARE_FEET</code>.
+     * @param showDMS     true if the desired angle format is degrees-minutes-seconds, false if the format is decimal
+     *                    degrees.
+     *
+     * @throws IllegalArgumentException if either <code>lengthUnits</code> or <code>areaUnits</code> is null.
+     */
+    public CMSUnitsFormat(String lengthUnits, String areaUnits, boolean showDMS)
+    {
+        if (lengthUnits == null)
+        {
+            String msg = Logging.getMessage("nullValue.LengthUnit");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        if (areaUnits == null)
+        {
+            String msg = Logging.getMessage("nullValue.AreaUnit");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.setDefaultLabels();
+        this.setDefaultFormats();
+        this.setLengthUnits(lengthUnits);
+        this.setAltitudeUnits(lengthUnits); // initialize to same as length units
+        this.setAreaUnits(areaUnits);
+        this.setShowDMS(showDMS);
+    }
+
+    /**
+     * Establishes the labels to use when displaying values other than length and area. A label is a string placed
+     * before the value and its units. Examples are <em>Latitude</em> 24.36, <em>UTM Zone:</em> 12, and <em>Eye
+     * Altitude:</em> 500 km, where the emphasized terms are the labels. Subclasses can override this method to
+     * establish labels other than the defaults. The default labels are drawn from the current message properties. The
+     * recognized labels are those indicated by the "LABEL_" constants defined by this class or by its subclasses.
+     */
+    protected void setDefaultLabels()
+    {
+
+        //
+        // Copied from src/gov/nasa/worldwind/util/MessageStrings.properties
+        // which is called in the original UnitsFormat.java class with
+        // Logging.getMessage(CONSTANT_NAME)
+//        this.setLabel(LABEL_LATITUDE, "Latitude ");
+//        this.setLabel(LABEL_LONGITUDE, "Longitude");
+//        this.setLabel(LABEL_LATLON_LAT, "Lat");
+//        this.setLabel(LABEL_LATLON_LON, "Lon");
+//        this.setLabel(LABEL_HEADING, "Heading");
+//        this.setLabel(LABEL_EYE_ALTITUDE, "Eye Altitude");
+//        this.setLabel(LABEL_PITCH, "Pitch");
+//        this.setLabel(LABEL_UTM_ZONE, "UTM_Zone");
+//        this.setLabel(LABEL_UTM_EASTING, "East");
+//        this.setLabel(LABEL_UTM_NORTHING, "North");
+//        this.setLabel(LABEL_TERRAIN_HEIGHT, "Terrain Elevation");
+
+        this.setLabel(LABEL_LATITUDE, Logging.getMessage(LABEL_LATITUDE));
+        this.setLabel(LABEL_LONGITUDE, Logging.getMessage(LABEL_LONGITUDE));
+        this.setLabel(LABEL_LATLON_LAT, Logging.getMessage(LABEL_LATLON_LAT));
+        this.setLabel(LABEL_LATLON_LON, Logging.getMessage(LABEL_LATLON_LON));
+        this.setLabel(LABEL_HEADING, Logging.getMessage(LABEL_HEADING));
+        this.setLabel(LABEL_EYE_ALTITUDE, Logging.getMessage(LABEL_EYE_ALTITUDE));
+        this.setLabel(LABEL_PITCH, Logging.getMessage(LABEL_PITCH));
+        this.setLabel(LABEL_UTM_ZONE, Logging.getMessage(LABEL_UTM_ZONE));
+        this.setLabel(LABEL_UTM_EASTING, Logging.getMessage(LABEL_UTM_EASTING));
+        this.setLabel(LABEL_UTM_NORTHING, Logging.getMessage(LABEL_UTM_NORTHING));
+        this.setLabel(LABEL_TERRAIN_HEIGHT, Logging.getMessage(LABEL_TERRAIN_HEIGHT));
+        this.setLabel(LABEL_DATUM, "Datum:");
+    }
+
+    /**
+     * Establishes the format declarations to use for certain values. Examples are " %,12.1f %s" for lengths and "
+     * %,11.1f" for UTM northings. Subclasses can override this method to establish formats other than the defaults. The
+     * value types that have associated formats are indicated by the "FORMAT_" constants defined by this class or by its
+     * subclasses.
+     */
+    protected void setDefaultFormats()
+    {
+        this.setFormat(FORMAT_LENGTH, " %,12.1f %s");
+        this.setFormat(FORMAT_AREA, " %,12.1f %s");
+        this.setFormat(FORMAT_PITCH, " %9.2f\u00b0");
+        this.setFormat(FORMAT_HEADING, " %9.2f\u00b0");
+        this.setFormat(FORMAT_UTM_NORTHING, " %,11.1f");
+        this.setFormat(FORMAT_UTM_EASTING, " %,11.1f");
+        this.setFormat(FORMAT_EYE_ALTITUDE, " %,6d %s");
+        this.setFormat(FORMAT_DECIMAL_DEGREES, "%9.4f\u00B0");
+        this.setFormat(FORMAT_TERRAIN_HEIGHT, " %,6d %s");
+    }
+
+    /**
+     * Set the label of a specified value type. See {@link #setDefaultLabels()} for a description and examples of
+     * labels.
+     *
+     * @param labelName a key identifying the label type. Available names are those indicated by the "LABEL_" constants
+     *                  defined by this class or by its subclasses
+     * @param label     the label to use for the specified value type.
+     *
+     * @throws IllegalArgumentException if either the label or label name is null.
+     */
+    public void setLabel(String labelName, String label)
+    {
+        if (labelName == null)
+        {
+            String msg = Logging.getMessage("nullValue.LabelKey");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        if (label == null)
+        {
+            String msg = Logging.getMessage("nullValue.Label");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.setValue(labelName, label);
+    }
+
+    /**
+     * Returns the label for a specified label name.
+     *
+     * @param labelName the name of the label to return.
+     *
+     * @return the label, or null if the label does not exist.
+     *
+     * @throws IllegalArgumentException if the label name is null.
+     */
+    public String getLabel(String labelName)
+    {
+        if (labelName == null)
+        {
+            String msg = Logging.getMessage("nullValue.LabelKey");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.getStringValue(labelName);
+    }
+
+    /**
+     * Set the format of a specified value type. See {@link #setDefaultFormats()} for a description and examples of
+     * formats.
+     *
+     * @param formatName a key identifying the value type that is to have the specified format. Available types are
+     *                   those indicated by the "FORMAT_" constants defined by this class or by its subclasses
+     * @param format     the label to use for the specified value type.
+     *
+     * @throws IllegalArgumentException if either the format or format name are null.
+     */
+    public void setFormat(String formatName, String format)
+    {
+        if (formatName == null)
+        {
+            String msg = Logging.getMessage("nullValue.FormatKey");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        if (format == null)
+        {
+            String msg = Logging.getMessage("nullValue.Format");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.setValue(formatName, format);
+    }
+
+    /**
+     * Returns the format for a specified value type.
+     *
+     * @param formatName the name of the value type whose format is desired.
+     *
+     * @return the format, or null if the format does not exist.
+     *
+     * @throws IllegalArgumentException if the format name is null.
+     */
+    public String getFormat(String formatName)
+    {
+        if (formatName == null)
+        {
+            String msg = Logging.getMessage("nullValue.FormatKey");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.getStringValue(formatName);
+    }
+
+    /**
+     * Indicates whether angles are displayed in degrees-minutes-seconds.
+     *
+     * @return true if angles are displayed in degrees-minutes seconds, false if they're displayed in decimal degrees.
+     */
+    public boolean isShowDMS()
+    {
+        return this.showDMS;
+    }
+
+    /**
+     * Specifies whether angles are displayed in degrees-minutes-seconds.
+     *
+     * @param showDMS true to display angles in degrees-minutes seconds, false to display them in decimal degrees.
+     */
+    public void setShowDMS(boolean showDMS)
+    {
+        this.showDMS = showDMS;
+    }
+
+    /**
+     * Returns the units symbol for the current length units. Examples are "m" for meters and "Nm" for nautical miles.
+     *
+     * @return the units symbol for the current length units.
+     */
+    public String getLengthUnitsSymbol()
+    {
+        return this.lengthUnitsSymbol;
+    }
+
+    /**
+     * Returns the current length units.
+     *
+     * @return the current length units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list of those
+     *         available.
+     */
+    public String getLengthUnits()
+    {
+        return this.lengthUnits;
+    }
+
+    /**
+     * Specifies the units in which to display length values. Units subsequently formatted by the instance are converted
+     * from meters to the desired units prior to formatting.
+     *
+     * @param lengthUnits the desired length units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list of
+     *                    those available.
+     *
+     * @throws IllegalArgumentException if <code>lengthUnits</code> is null.
+     */
+    public void setLengthUnits(String lengthUnits)
+    {
+        if (lengthUnits == null)
+        {
+            String msg = Logging.getMessage("nullValue.LengthUnit");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.lengthUnits = lengthUnits;
+
+        if (lengthUnits.equals(CMSUnitsFormat.KILOMETERS))
+        {
+            this.lengthUnitsMultiplier = WWMath.METERS_TO_KILOMETERS;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_KILOMETERS;
+        }
+        else if (lengthUnits.equals(CMSUnitsFormat.MILES))
+        {
+            this.lengthUnitsMultiplier = WWMath.METERS_TO_MILES;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_MILES;
+        }
+        else if (lengthUnits.equals(CMSUnitsFormat.NAUTICAL_MILES))
+        {
+            this.lengthUnitsMultiplier = WWMath.METERS_TO_NAUTICAL_MILES;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_NAUTICAL_MILES;
+        }
+        else if (lengthUnits.equals(CMSUnitsFormat.YARDS))
+        {
+            this.lengthUnitsMultiplier = WWMath.METERS_TO_YARDS;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_YARDS;
+        }
+        else if (lengthUnits.equals(CMSUnitsFormat.FEET))
+        {
+            this.lengthUnitsMultiplier = WWMath.METERS_TO_FEET;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_FEET;
+        }
+        else
+        {
+            this.lengthUnitsMultiplier = 1d;
+            this.lengthUnitsSymbol = CMSUnitsFormat.SYMBOL_METERS;
+        }
+    }
+
+    /**
+     * Indicates the multiplier used to convert from meters to the current length units.
+     *
+     * @return the conversion multiplier to convert meters to the current length units.
+     */
+    public double getLengthUnitsMultiplier()
+    {
+        return this.lengthUnitsMultiplier;
+    }
+
+    /**
+     * Returns the units symbol for the current altitude units. Examples are "m" for meters and "Nm" for nautical
+     * miles.
+     *
+     * @return the units symbol for the current altitude units.
+     */
+    public String getAltitudeUnitsSymbol()
+    {
+        return this.altitudeUnitsSymbol;
+    }
+
+    /**
+     * Returns the current altitude units.
+     *
+     * @return the current altitude units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list of those
+     *         available.
+     */
+    public String getAltitudeUnits()
+    {
+        return this.altitudeUnits;
+    }
+
+    /**
+     * Specifies the units in which to display altitude values. Units subsequently formatted by the instance are
+     * converted from meters to the desired units prior to formatting.
+     *
+     * @param altitudeUnits the desired altitude units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list
+     *                      of those available.
+     *
+     * @throws IllegalArgumentException if <code>lengthUnits</code> is null.
+     */
+    public void setAltitudeUnits(String altitudeUnits)
+    {
+        if (altitudeUnits == null)
+        {
+            String msg = Logging.getMessage("nullValue.AltitudeUnit");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.altitudeUnits = altitudeUnits;
+
+        if (altitudeUnits.equals(CMSUnitsFormat.KILOMETERS))
+        {
+            this.altitudeUnitsMultiplier = WWMath.METERS_TO_KILOMETERS;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_KILOMETERS;
+        }
+        else if (altitudeUnits.equals(CMSUnitsFormat.MILES))
+        {
+            this.altitudeUnitsMultiplier = WWMath.METERS_TO_MILES;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_MILES;
+        }
+        else if (altitudeUnits.equals(CMSUnitsFormat.NAUTICAL_MILES))
+        {
+            this.altitudeUnitsMultiplier = WWMath.METERS_TO_NAUTICAL_MILES;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_NAUTICAL_MILES;
+        }
+        else if (altitudeUnits.equals(CMSUnitsFormat.YARDS))
+        {
+            this.altitudeUnitsMultiplier = WWMath.METERS_TO_YARDS;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_YARDS;
+        }
+        else if (altitudeUnits.equals(CMSUnitsFormat.FEET))
+        {
+            this.altitudeUnitsMultiplier = WWMath.METERS_TO_FEET;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_FEET;
+        }
+        else
+        {
+            this.altitudeUnitsMultiplier = 1d;
+            this.altitudeUnitsSymbol = CMSUnitsFormat.SYMBOL_METERS;
+        }
+    }
+
+    /**
+     * Indicates the multiplier used to convert from meters to the current altitude units.
+     *
+     * @return the conversion multiplier to convert meters to the current altitude units.
+     */
+    public double getAltitudeUnitsMultiplier()
+    {
+        return this.altitudeUnitsMultiplier;
+    }
+
+    /**
+     * Returns the current area units.
+     *
+     * @return the current area units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list of those
+     *         available.
+     */
+    public String getAreaUnits()
+    {
+        return this.areaUnits;
+    }
+
+    /**
+     * Specifies the units in which to display area values. Units subsequently formatted by the instance are converted
+     * from square meters to the desired units prior to formatting.
+     *
+     * @param areaUnits the desired length units. See {@link #CMSUnitsFormat(String, String, boolean)} for the list of
+     *                  those available.
+     *
+     * @throws IllegalArgumentException if <code>areaUnits</code> is null.
+     */
+    public void setAreaUnits(String areaUnits)
+    {
+        if (areaUnits == null)
+        {
+            String msg = Logging.getMessage("nullValue.AreaUnit");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.areaUnits = areaUnits;
+
+        if (areaUnits.equals(CMSUnitsFormat.SQUARE_KILOMETERS))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_SQUARE_KILOMETERS;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_SQUARE_KILOMETERS;
+        }
+        else if (areaUnits.equals(CMSUnitsFormat.SQUARE_MILES))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_SQUARE_MILES;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_SQUARE_MILES;
+        }
+        else if (areaUnits.equals(CMSUnitsFormat.HECTARE))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_HECTARES;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_HECTARE;
+        }
+        else if (areaUnits.equals(CMSUnitsFormat.ACRE))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_ACRES;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_ACRE;
+        }
+        else if (areaUnits.equals(CMSUnitsFormat.SQUARE_YARDS))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_SQUARE_YARDS;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_SQUARE_YARDS;
+        }
+        else if (areaUnits.equals(CMSUnitsFormat.SQUARE_FEET))
+        {
+            this.areaUnitsMultiplier = WWMath.SQUARE_METERS_TO_SQUARE_FEET;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_SQUARE_FEET;
+        }
+        else
+        {
+            this.areaUnitsMultiplier = 1d;
+            this.areaUnitsSymbol = CMSUnitsFormat.SYMBOL_SQUARE_METERS;
+        }
+    }
+
+    /**
+     * Indicates the multiplier used to convert from square meters to the current area units.
+     *
+     * @return the conversion multiplier to convert square meters to the current area units.
+     */
+    public double getAreaUnitsMultiplier()
+    {
+        return this.areaUnitsMultiplier;
+    }
+
+    /**
+     * Returns the units symbol for the current area units. Examples are "m\u00b2" for square meters and "miles\u00b2"
+     * for square miles.
+     *
+     * @return the units symbol for the current area units.
+     */
+    public String getAreaUnitsSymbol()
+    {
+        return this.areaUnitsSymbol;
+    }
+
+    /**
+     * Sets the length and area units to those common for a given units system. Recognized systems are {@link
+     * #METRIC_SYSTEM}, which uses kilometers and square kilometers, and {@link #IMPERIAL_SYSTEM}, which uses miles and
+     * square miles.
+     *
+     * @param unitsSystem the desired units system, either <code>METRIC_SYSTEM</code> or <code>IMPERIAL_SYSTEM</code>.
+     *
+     * @throws IllegalArgumentException if <code>unitsSystem</code> is null.
+     */
+    public void setUnitsSystem(String unitsSystem)
+    {
+        if (unitsSystem == null)
+        {
+            String msg = Logging.getMessage("nullValue.UnitsSystem");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        if (unitsSystem.equals(CMSUnitsFormat.IMPERIAL_SYSTEM))
+        {
+            this.setLengthUnits(CMSUnitsFormat.MILES);
+            this.setAltitudeUnits(CMSUnitsFormat.MILES);
+            this.setAreaUnits(CMSUnitsFormat.SQUARE_MILES);
+        }
+        else
+        {
+            this.setLengthUnits(CMSUnitsFormat.KILOMETERS);
+            this.setAltitudeUnits(CMSUnitsFormat.KILOMETERS);
+            this.setAreaUnits(CMSUnitsFormat.SQUARE_KILOMETERS);
+        }
+    }
+
+    /**
+     * Indicates the unit system of the current length units. The available systems are {@link #METRIC_SYSTEM} and
+     * {@link #IMPERIAL_SYSTEM}.
+     *
+     * @return the current units system for lengths.
+     */
+    public String getLengthUnitsSystem()
+    {
+        if (this.getLengthUnits().equals(CMSUnitsFormat.METERS)
+            || this.getLengthUnits().equals(CMSUnitsFormat.KILOMETERS))
+            return CMSUnitsFormat.METRIC_SYSTEM;
+        else
+            return CMSUnitsFormat.IMPERIAL_SYSTEM;
+    }
+
+    /**
+     * Indicates the unit system of the current area units. The available systems are {@link #METRIC_SYSTEM} and {@link
+     * #IMPERIAL_SYSTEM}.
+     *
+     * @return the current units system for areas.
+     */
+    public String getAreaUnitsSystem()
+    {
+        if (this.getAreaUnits().equals(CMSUnitsFormat.SQUARE_METERS)
+            || this.getAreaUnits().equals(CMSUnitsFormat.SQUARE_KILOMETERS)
+            || this.getAreaUnits().equals(CMSUnitsFormat.HECTARE)
+            )
+            return CMSUnitsFormat.METRIC_SYSTEM;
+        else
+            return CMSUnitsFormat.IMPERIAL_SYSTEM;
+    }
+
+    /**
+     * Format an angle of latitude and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_LATITUDE} and angle format.
+     *
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle and ending with the new-line character.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String latitudeNL(Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angleNL(this.getLabel(LABEL_LATITUDE), angle);
+    }
+
+    /**
+     * Format an angle of latitude.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_LATITUDE} and angle format.
+     *
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String latitude(Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angle(this.getLabel(LABEL_LATITUDE), angle);
+    }
+
+    /**
+     * Format an angle of longitude and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_LONGITUDE} and angle format.
+     *
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle and ending with the new-line character.
+     */
+    public String longitudeNL(Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angleNL(this.getLabel(LABEL_LONGITUDE), angle);
+    }
+
+    /**
+     * Format an angle of longitude.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_LONGITUDE} and angle format.
+     *
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String longitude(Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angle(this.getLabel(LABEL_LONGITUDE), angle);
+    }
+
+    /**
+     * Format an angle of heading according to the current angle format, and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_HEADING} and angle format.
+     *
+     * @param angle the heading angle to format.
+     *
+     * @return a string containing the formatted angle and ending with the new-line character.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String headingNL(Angle angle)
+    {
+        return this.angleNL(this.getLabel(LABEL_HEADING), angle);
+    }
+
+    /**
+     * Format an angle of heading according to the current angle format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_HEADING} and angle format.
+     *
+     * @param angle the heading angle to format.
+     *
+     * @return a string containing the formatted angle.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String heading(Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angle(this.getLabel(LABEL_HEADING), angle);
+    }
+
+    /**
+     * Format an angle of heading in degrees according to the current angle format, and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_HEADING} and {@link #FORMAT_HEADING}. The default
+     * <code>FORMAT_HEADING</code> is " %9.2f\u00b0".
+     *
+     * @param heading the angle to format.
+     *
+     * @return a string containing the formatted angle and ending with the new-line character.
+     */
+    public String headingNL(double heading)
+    {
+        return this.heading(heading) + NL;
+    }
+
+    /**
+     * Format an angle of heading in degrees according to the current angle format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_HEADING} and {@link #FORMAT_HEADING}. The default
+     * <code>FORMAT_HEADING</code> is " %9.2f\u00b0".
+     *
+     * @param heading the angle to format.
+     *
+     * @return a string containing the formatted angle.
+     */
+    public String heading(double heading)
+    {
+        return String.format(this.getLabel(LABEL_HEADING) + this.getFormat(FORMAT_HEADING), heading);
+    }
+
+    /**
+     * Format angles of latitude and longitude according to the current angle format, and append a new-line character.
+     * <p>
+     * The values are formatted using the current {@link #LABEL_LATLON_LAT}, {@link #LABEL_LATLON_LON} and angle
+     * format.
+     *
+     * @param latlon the angles to format.
+     *
+     * @return a string containing the formatted angles and ending with the new-line character.
+     *
+     * @throws IllegalArgumentException if <code>latlon</code> is null.
+     */
+    public String latLonNL(LatLon latlon)
+    {
+        if (latlon == null)
+        {
+            String msg = Logging.getMessage("nullValue.LatLonIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.latLon(latlon) + NL;
+    }
+
+    /**
+     * Format angles of latitude and longitude according to the current angle format.
+     * <p>
+     * The values are formatted using the current {@link #LABEL_LATLON_LAT}, {@link #LABEL_LATLON_LON} and angle
+     * format.
+     *
+     * @param latlon the angles to format.
+     *
+     * @return a string containing the formatted angles.
+     *
+     * @throws IllegalArgumentException if <code>latlon</code> is null.
+     */
+    public String latLon(LatLon latlon)
+    {
+        if (latlon == null)
+        {
+            String msg = Logging.getMessage("nullValue.LatLonIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return String.format("%s %s", this.angle(this.getLabel(LABEL_LATLON_LAT), latlon.getLatitude()),
+            this.angle(this.getLabel(LABEL_LATLON_LON), latlon.getLongitude())).trim();
+    }
+
+    /**
+     * Format angles with {@link #latLon2(LatLon)} and append a new-line character.
+     *
+     * @param latlon the angles to format.
+     *
+     * @return a string containing the formatted angles and ending with the new-line character.
+     *
+     * @throws IllegalArgumentException if <code>latlon</code> is null.
+     */
+    public String latLon2NL(LatLon latlon)
+    {
+        if (latlon == null)
+        {
+            String msg = Logging.getMessage("nullValue.LatLonIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.latLon2(latlon) + NL;
+    }
+
+    /**
+     * Format angles of latitude and longitude according to the current angle format and in the form "20\u00B0N
+     * 85\u00B0S".
+     *
+     * @param latlon the angles to format.
+     *
+     * @return a string containing the formatted angles.
+     *
+     * @throws IllegalArgumentException if <code>latlon</code> is null.
+     */
+    public String latLon2(LatLon latlon)
+    {
+        if (latlon == null)
+        {
+            String msg = Logging.getMessage("nullValue.LatLonIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        String latAngle = this.angle("", Angle.fromDegrees(Math.abs(latlon.getLatitude().degrees)));
+        String latString = String.format("%s%s", latAngle, latlon.getLatitude().degrees >= 0 ? "N" : "S");
+
+        String lonAngle = this.angle("", Angle.fromDegrees(Math.abs(latlon.getLongitude().degrees)));
+        String lonString = String.format("%s%s", lonAngle, latlon.getLongitude().degrees >= 0 ? "E" : "W");
+
+        return String.format("%s %s", latString, lonString);
+    }
+
+    /**
+     * Format an angle according to the current angle format. Prepend a specified label and append a new-line
+     * character.
+     *
+     * @param label a label to prepend to the formatted angle. May be null to indicate no label.
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle prepended with the specified label and ending with the new-line
+     *         character.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String angleNL(String label, Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        return this.angle(label, angle) + NL;
+    }
+
+    /**
+     * Format an angle according to the current angle format. Prepend a specified label.
+     *
+     * @param label a label to prepend to the formatted angle. May be null to indicate no label.
+     * @param angle the angle to format.
+     *
+     * @return a string containing the formatted angle prepended with the specified label.
+     *
+     * @throws IllegalArgumentException if the angle is null.
+     */
+    public String angle(String label, Angle angle)
+    {
+        if (angle == null)
+        {
+            String msg = Logging.getMessage("nullValue.AngleIsNull");
+            Logging.logger().severe(msg);
+            throw new IllegalArgumentException(msg);
+        }
+
+        String s;
+        if (this.isShowDMS())
+            s = String.format("%s", angle.toFormattedDMSString()).trim();
+        else
+            s = String.format(this.getFormat(FORMAT_DECIMAL_DEGREES), angle.degrees).trim();
+
+        return label != null ? label + " " + s : s;
+    }
+
+    /**
+     * Format an eye altitude according to the current eye altitude format, and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_EYE_ALTITUDE}, {@link #FORMAT_EYE_ALTITUDE} and length
+     * format.
+     *
+     * @param metersAltitude the eye altitude to format, in meters.
+     *
+     * @return a string containing the formatted eye altitude and ending with the new-line character.
+     */
+    public String eyeAltitudeNL(double metersAltitude)
+    {
+        return this.eyeAltitude(metersAltitude) + NL;
+    }
+
+    /**
+     * Format an eye altitude according to the current eye altitude format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_EYE_ALTITUDE}, {@link #FORMAT_EYE_ALTITUDE} and length
+     * format.
+     *
+     * @param metersAltitude the eye altitude to format, in meters.
+     *
+     * @return a string containing the formatted eye altitude.
+     */
+    public String eyeAltitude(double metersAltitude)
+    {
+        if (this.getFormat(FORMAT_EYE_ALTITUDE).contains("f"))
+            return String.format(this.getLabel(LABEL_EYE_ALTITUDE) + this.getFormat(FORMAT_EYE_ALTITUDE),
+                metersAltitude * this.getAltitudeUnitsMultiplier(),
+                this.getAltitudeUnitsSymbol());
+        else
+            return String.format(this.getLabel(LABEL_EYE_ALTITUDE) + this.getFormat(FORMAT_EYE_ALTITUDE),
+                (int) Math.round(metersAltitude * this.getAltitudeUnitsMultiplier()),
+                this.getAltitudeUnitsSymbol());
+    }
+
+    /**
+     * Format an angle of pitch according to the current angle format, and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_PITCH} and {@link #FORMAT_PITCH}. The default
+     * <code>FORMAT_PITCH</code> is " %9.2f\u00b0".
+     *
+     * @param pitch the angle to format.
+     *
+     * @return a string containing the formatted angle and ending with the new-line character.
+     */
+    public String pitchNL(double pitch)
+    {
+        return this.pitch(pitch) + NL;
+    }
+
+    /**
+     * Format an angle of pitch according to the current angle format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_PITCH} and {@link #FORMAT_PITCH}. The default
+     * <code>FORMAT_PITCH</code> is " %9.2f\u00b0".
+     *
+     * @param pitch the angle to format.
+     *
+     * @return a string containing the formatted angle.
+     */
+    public String pitch(double pitch)
+    {
+        return String.format(this.getLabel(LABEL_PITCH) + this.getFormat(FORMAT_PITCH), pitch);
+    }
+
+    /**
+     * Format a UTM zone according to the current UTM zone format and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_ZONE}.
+     *
+     * @param zone the UTM zone to format.
+     *
+     * @return the formatted UTM zone ending with a new-line character.
+     */
+    public String utmZoneNL(int zone)
+    {
+        return this.utmZone(zone) + NL;
+    }
+
+    /**
+     * Format a UTM zone according to the current UTM zone format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_ZONE}.
+     *
+     * @param zone the UTM zone to format.
+     *
+     * @return the formatted UTM zone.
+     */
+    public String utmZone(int zone)
+    {
+        return String.format(this.getLabel(LABEL_UTM_ZONE) + " %2d", zone);
+    }
+
+    /**
+     * Format a UTM northing value according to the current UTM northing format and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_NORTHING} and current {@link #FORMAT_UTM_NORTHING}.
+     * The default UTM northing format is " %,11.1f". No units symbol is included in the formatted string because UTM
+     * northing units are always meters.
+     *
+     * @param northing the UTM northing to format.
+     *
+     * @return the formatted UTM northing ending with a new-line character.
+     */
+    public String utmNorthingNL(double northing)
+    {
+        return this.utmNorthing(northing) + NL;
+    }
+
+    /**
+     * Format a UTM northing value according to the current UTM northing format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_NORTHING} and current {@link #FORMAT_UTM_NORTHING}.
+     * The default UTM northing format is " %,11.1f". No units symbol is included in the formatted string because UTM
+     * northing units are always meters.
+     *
+     * @param northing the UTM northing to format.
+     *
+     * @return the formatted UTM northing.
+     */
+    public String utmNorthing(double northing)
+    {
+        return String.format(this.getLabel(LABEL_UTM_NORTHING) + this.getFormat(FORMAT_UTM_NORTHING), northing);
+    }
+
+    /**
+     * Format a UTM easting value according to the current UTM easting format and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_EASTING} and current {@link #FORMAT_UTM_EASTING}. The
+     * default UTM easting format is " %,11.1f". No units symbol is included in the formatted string because UTM easting
+     * units are always meters.
+     *
+     * @param easting the UTM northing to format.
+     *
+     * @return the formatted UTM easting ending with a new-line character.
+     */
+    public String utmEastingNL(double easting)
+    {
+        return this.utmEasting(easting) + NL;
+    }
+
+    /**
+     * Format a UTM easting value according to the current UTM easting format.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_UTM_EASTING} and current {@link #FORMAT_UTM_EASTING}. The
+     * default UTM easting format is " %,11.1f". No units symbol is included in the formatted string because UTM easting
+     * units are always meters.
+     *
+     * @param easting the UTM northing to format.
+     *
+     * @return the formatted UTM easting.
+     */
+    public String utmEasting(double easting)
+    {
+        return String.format(this.getLabel(LABEL_UTM_EASTING) + this.getFormat(FORMAT_UTM_EASTING), easting);
+    }
+
+    /**
+     * Format a terrain height value according to the current configuration and append a new-line character. See {@link
+     * #terrainHeight(double, double)} for a description of the formatting.
+     *
+     * @param metersElevation      the terrain height in meters.
+     * @param verticalExaggeration the vertical exaggeration to apply to the terrain height.
+     *
+     * @return the formatted terrain height ending with a new-line character.
+     */
+    public String terrainHeightNL(double metersElevation, double verticalExaggeration)
+    {
+        return this.terrainHeight(metersElevation, verticalExaggeration) + NL;
+    }
+
+    /**
+     * Format a terrain height value according to the current configuration and append a new-line character.
+     * <p>
+     * The value is formatted using the current {@link #LABEL_TERRAIN_HEIGHT}, {@link #FORMAT_TERRAIN_HEIGHT} and length
+     * units symbol. The default terrain height format is " (ve %3.1f): %,6d %s", where the %3.1f specifier stands for
+     * the vertical exaggeration, the %,6d specifier stands for the terrain height, and the %s specifier stands for the
+     * units symbol.
+     * <p>
+     * Note: While the <code>FORMAT_TERRAIN_HEIGHT</code> string may be specified by the application, the terrain height
+     * components are always passed to the internal formatter in the order: vertical exaggeration, terrain height, units
+     * symbol.
+     *
+     * @param metersElevation      the terrain height in meters.
+     * @param verticalExaggeration the vertical exaggeration to apply to the terrain height.
+     *
+     * @return the formatted terrain height ending with a new-line character.
+     */
+    public String terrainHeight(double metersElevation, double verticalExaggeration)
+    {
+        double multiplier;
+        String symbol;
+
+        if (this.getLengthUnitsSystem().equals(CMSUnitsFormat.METRIC_SYSTEM))
+        {
+            multiplier = 1d;
+            symbol = CMSUnitsFormat.SYMBOL_METERS;
+        }
+        else
+        {
+            multiplier = WWMath.METERS_TO_FEET;
+            symbol = CMSUnitsFormat.SYMBOL_FEET;
+        }
+
+        return String.format(this.getLabel(LABEL_TERRAIN_HEIGHT) + getFormat(FORMAT_TERRAIN_HEIGHT),
+            (int) Math.round((metersElevation / verticalExaggeration) * multiplier), symbol);
+    }
+
+    /**
+     * Format a length according to the current length configuration. Prepend a specified label and append a new-line
+     * character.
+     * <p>
+     * The value is formatted using the current {@link #FORMAT_LENGTH} and length units symbol,  and is converted to the
+     * current length units prior to formatting. The default length format is " %,12.1f %s", where the %s specifier
+     * stands for the units symbol.
+     *
+     * @param label  the label to prepend to the formatted length. May be null to indicate no label.
+     * @param meters the length to format, in meters.
+     *
+     * @return the formatted length with the specified label prepended and a new-line character appended.
+     */
+    public String lengthNL(String label, double meters)
+    {
+        return this.length(label, meters) + NL;
+    }
+
+    /**
+     * Format a length according to the current length configuration. Prepend a specified label.
+     * <p>
+     * The value is formatted using the current {@link #FORMAT_LENGTH} and length units symbol,  and is converted to the
+     * current length units prior to formatting. The default length format is " %,12.1f %s", where the %s specifier
+     * stands for the units symbol.
+     *
+     * @param label  the label to prepend to the formatted length. May be null to indicate no label.
+     * @param meters the length to format, in meters.
+     *
+     * @return the formatted length with the specified label prepended.
+     */
+    public String length(String label, double meters)
+    {
+        String s = String.format(this.getFormat(FORMAT_LENGTH), meters * this.getLengthUnitsMultiplier(),
+            this.getLengthUnitsSymbol()).trim();
+
+        return label != null ? label + " " + s : s;
+    }
+
+    /**
+     * Format an area value according to the current length configuration. Prepend a specified label and append a
+     * new-line character.
+     * <p>
+     * The value is formatted using the current {@link #FORMAT_AREA} and area units symbol,  and is converted to the
+     * current area units prior to formatting. The default area format is " %,12.1f %s", where the %s specifier stands
+     * for the units symbol.
+     *
+     * @param label        the label to prepend to the formatted length. May be null to indicate no label.
+     * @param squareMeters the area value to format, in square meters.
+     *
+     * @return the formatted area with the specified label prepended and a new-line character appended.
+     */
+    public String areaNL(String label, double squareMeters)
+    {
+        return this.area(label, squareMeters) + NL;
+    }
+
+    /**
+     * Format an area value according to the current length configuration and prepend a specified label.
+     * <p>
+     * The value is formatted using the current {@link #FORMAT_AREA} and area units symbol,  and is converted to the
+     * current area units prior to formatting. The default area format is " %,12.1f %s", where the %s specifier stands
+     * for the units symbol.
+     *
+     * @param label        the label to prepend to the formatted length. May be null to indicate no label.
+     * @param squareMeters the area value to format, in square meters.
+     *
+     * @return the formatted area with the specified label prepended.
+     */
+    public String area(String label, double squareMeters)
+    {
+        String s = String.format(this.getFormat(FORMAT_AREA), squareMeters * this.getAreaUnitsMultiplier(),
+            this.getAreaUnitsSymbol()).trim();
+
+        return label != null ? label + " " + s : s;
+    }
+}

--- a/src/gov/nasa/cms/features/coordinates/CMSWWOUnitsFormat.java
+++ b/src/gov/nasa/cms/features/coordinates/CMSWWOUnitsFormat.java
@@ -4,21 +4,21 @@
  * All Rights Reserved.
  */
 
-package gov.nasa.worldwindx.applications.worldwindow.util;
+package gov.nasa.cms.features.coordinates;
 
-import gov.nasa.cms.features.coordinates.CMSUnitsFormat;
+import gov.nasa.worldwind.avlist.AVKey;
 import gov.nasa.worldwind.util.UnitsFormat;
 
 /**
  * @author tag
  * @version $Id: WWOUnitsFormat.java 1171 2013-02-11 21:45:02Z dcollins $
  */
-public class WWOUnitsFormat extends UnitsFormat
+public class CMSWWOUnitsFormat extends CMSUnitsFormat
 {
     private boolean showUTM = true;
     private boolean showWGS84 = true;
 
-    public WWOUnitsFormat()
+    public CMSWWOUnitsFormat()
     {
         super(CMSUnitsFormat.KILOMETERS, UnitsFormat.SQUARE_KILOMETERS, false);
     }

--- a/src/gov/nasa/cms/features/coordinates/CoordinatesDisplay.java
+++ b/src/gov/nasa/cms/features/coordinates/CoordinatesDisplay.java
@@ -36,12 +36,11 @@ import gov.nasa.worldwind.geom.coords.UTMCoord;
 import gov.nasa.worldwind.layers.*;
 import gov.nasa.worldwind.pick.PickedObject;
 import gov.nasa.worldwind.render.*;
-import gov.nasa.worldwind.util.UnitsFormat;
+//import gov.nasa.worldwind.util.CMSUnitsFormat;
+import gov.nasa.cms.features.coordinates.CMSUnitsFormat;
 import gov.nasa.worldwind.view.orbit.OrbitView;
-import gov.nasa.worldwindx.applications.worldwindow.core.*;
-import gov.nasa.worldwindx.applications.worldwindow.core.layermanager.LayerPath;
-import gov.nasa.worldwindx.applications.worldwindow.features.AbstractOnDemandLayerFeature;
-import gov.nasa.worldwindx.applications.worldwindow.util.WWOUnitsFormat;
+//import gov.nasa.worldwindx.applications.worldwindow.core.Constants;
+
 
 import java.awt.*;
 import java.util.Iterator;
@@ -116,7 +115,7 @@ public class CoordinatesDisplay
         attrs.setDrawOffset(new Point(-width -665, -height - 140));
 
         CoordAnnotationLayer layer = new CoordAnnotationLayer();
-        layer.setValue(Constants.SCREEN_LAYER, true);
+        layer.setValue(WorldWindowConstants.SCREEN_LAYER, true);
         layer.setPickEnabled(false);
         layer.addAnnotation(anno);
         layer.setName("Coordinates Display");
@@ -158,20 +157,20 @@ public class CoordinatesDisplay
         Position eyePosition = dc.getView().getEyePosition();
         if (eyePosition != null)
         {
-            WWOUnitsFormat units = this.cms.getUnits();
-            String origFormat = units.getFormat(UnitsFormat.FORMAT_EYE_ALTITUDE);
+            CMSWWOUnitsFormat units = this.cms.getUnits();
+            String origFormat = units.getFormat(CMSUnitsFormat.FORMAT_EYE_ALTITUDE);
             String tempFormat = origFormat;
 
             if (Math.abs(eyePosition.getElevation() * units.getLengthUnitsMultiplier()) < 10)
             {
                 tempFormat = " %,6.3f %s";
-                units.setFormat(UnitsFormat.FORMAT_EYE_ALTITUDE, tempFormat);
+                units.setFormat(CMSUnitsFormat.FORMAT_EYE_ALTITUDE, tempFormat);
             }
 
             sb.append(this.cms.getUnits().eyeAltitudeNL(eyePosition.getElevation()));
 
             if (!tempFormat.equals(origFormat))
-                units.setFormat(UnitsFormat.FORMAT_EYE_ALTITUDE, origFormat);
+                units.setFormat(CMSUnitsFormat.FORMAT_EYE_ALTITUDE, origFormat);
         }
         else
         {
@@ -188,9 +187,9 @@ public class CoordinatesDisplay
         }
         else
         {
-            sb.append(this.cms.getUnits().getStringValue(UnitsFormat.LABEL_LATITUDE)).append("\n");
-            sb.append(this.cms.getUnits().getStringValue(UnitsFormat.LABEL_LONGITUDE)).append("\n");
-            sb.append(this.cms.getUnits().getStringValue(UnitsFormat.LABEL_TERRAIN_HEIGHT)).append("\n");
+            sb.append(this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_LATITUDE)).append("\n");
+            sb.append(this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_LONGITUDE)).append("\n");
+            sb.append(this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_TERRAIN_HEIGHT)).append("\n");
         }
 
         sb.append(this.cms.getUnits().pitchNL(computePitch(dc.getView())));
@@ -200,7 +199,7 @@ public class CoordinatesDisplay
 
         if (cms.getUnits().isShowUTM())
         {
-            sb.append(datum);
+//            sb.append(datum);
             if (currentPosition != null)
             {
                 try
@@ -215,27 +214,27 @@ public class CoordinatesDisplay
                 catch (Exception e)
                 {
                     sb.append(String.format(
-                        this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_ZONE) + "\n"));
+                        this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_ZONE) + "\n"));
                     sb.append(String.format(
-                        this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_EASTING) + "\n"));
+                        this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_EASTING) + "\n"));
                     sb.append(String.format(
-                        this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_NORTHING) + "\n"));
+                        this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_NORTHING) + "\n"));
                 }
             }
             else
             {
                 sb.append(
-                    String.format(this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_ZONE) + "\n"));
+                    String.format(this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_ZONE) + "\n"));
                 sb.append(String.format(
-                    this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_EASTING) + "\n"));
+                    this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_EASTING) + "\n"));
                 sb.append(String.format(
-                    this.cms.getUnits().getStringValue(UnitsFormat.LABEL_UTM_NORTHING) + "\n"));
+                    this.cms.getUnits().getStringValue(CMSUnitsFormat.LABEL_UTM_NORTHING) + "\n"));
             }
         }
-        else
-        {
-            sb.append(datum);
-        }
+//        else
+//        {
+//            sb.append(datum);
+//        }
 
         return sb.toString();
     }

--- a/src/gov/nasa/cms/features/coordinates/WorldWindowConstants.java
+++ b/src/gov/nasa/cms/features/coordinates/WorldWindowConstants.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2012 United States Government as represented by the Administrator of the
+ * National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ */
+
+package gov.nasa.cms.features.coordinates;
+
+/**
+ * @author tag
+ * @version $Id: Constants.java 1171 2013-02-11 21:45:02Z dcollins $
+ */
+public interface WorldWindowConstants
+{
+    // Names and titles
+    String APPLICATION_DISPLAY_NAME = "gov.nasa.worldwindx.applications.worldwindow.ApplicationDisplayName";
+
+    // Services
+    String IMAGE_SERVICE = "gov.nasa.worldwindx.applications.worldwindow.ImageService";
+
+    // Core object IDs
+    String APP_PANEL = "gov.nasa.worldwindx.applications.worldwindow.AppPanel";
+    String APP_FRAME = "gov.nasa.worldwindx.applications.worldwindow.AppFrame";
+    String CONTROLS_PANEL = "gov.nasa.worldwindx.applications.worldwindow.ControlsPanel";
+    String MENU_BAR = "gov.nasa.worldwindx.applications.worldwindow.MenuBar";
+    String NETWORK_STATUS_SIGNAL = "gov.nasa.worldwindx.applications.worldwindow.NetworkStatusSignal";
+    String TOOL_BAR = "gov.nasa.worldwindx.applications.worldwindow.ToolBar";
+    String STATUS_PANEL = "gov.nasa.worldwindx.applications.worldwindow.StatusPanel";
+    String WW_PANEL = "gov.nasa.worldwindx.applications.worldwindow.WWPanel";
+
+    // Miscellaneous
+    String ACCELERATOR_SUFFIX = ".Accelerator";
+    String ACTION_COMMAND = "gov.nasa.worldwindx.applications.worldwindow.ActionCommand";
+    String CONTEXT_MENU_INFO = "gov.nasa.worldwindx.applications.worldwindow.ContextMenuString";
+    String FILE_MENU = "gov.nasa.worldwindx.applications.worldwindow.feature.FileMenu";
+    String INFO_PANEL_TEXT = "gov.nasa.worldwindx.applications.worldwindow.InfoPanelText";
+    String ON_STATE = "gov.nasa.worldwindx.applications.worldwindow.OnState";
+    String RADIO_GROUP = "gov.nasa.worldwindx.applications.worldwindow.StatusBarMessage";
+    String STATUS_BAR_MESSAGE = "gov.nasa.worldwindx.applications.worldwindow.StatusBarMessage";
+
+    // Layer types
+    String INTERNAL_LAYER = "gov.nasa.worldwindx.applications.worldwindow.InternalLayer"; // application controls, etc.
+    String ACTIVE_LAYER = "gov.nasa.worldwindx.applications.worldwindow.ActiveLayer"; // force display in active layers
+    String USER_LAYER = "gov.nasa.worldwindx.applications.worldwindow.UserLayer"; // User-generated layers
+    String SCREEN_LAYER = "gov.nasa.worldwindx.applications.worldwindow.ScreenLayer";
+        // in-screen application controls, etc.
+
+    // Feature IDs
+    String FEATURE = "gov.nasa.worldwindx.applications.worldwindow.feature";
+    String FEATURE_ID = "gov.nasa.worldwindx.applications.worldwindow.FeatureID";
+    String FEATURE_ACTIVE_LAYERS_PANEL = "gov.nasa.worldwindx.applications.worldwindow.feature.ActiveLayersPanel";
+    String FEATURE_COMPASS = "gov.nasa.worldwindx.applications.worldwindow.feature.Compass";
+    String FEATURE_CROSSHAIR = "gov.nasa.worldwindx.applications.worldwindow.feature.Crosshair";
+    String FEATURE_COORDINATES_DISPLAY = "gov.nasa.worldwindx.applications.worldwindow.feature.CoordinatesDisplay";
+    String FEATURE_EXTERNAL_LINK_CONTROLLER
+        = "gov.nasa.worldwindx.applications.worldwindow.feature.ExternalLinkController";
+    String FEATURE_GAZETTEER = "gov.nasa.worldwindx.applications.worldwindow.feature.Gazetteer";
+    String FEATURE_GAZETTEER_PANEL = "gov.nasa.worldwindx.applications.worldwindow.feature.GazetteerPanel";
+    String FEATURE_GRATICULE = "gov.nasa.worldwindx.applications.worldwindow.feature.Graticule";
+    String FEATURE_ICON_CONTROLLER = "gov.nasa.worldwindx.applications.worldwindow.feature.IconController";
+    String FEATURE_IMPORT_IMAGERY = "gov.nasa.worldwindx.applications.worldwindow.feature.ImportImagery";
+    String FEATURE_INFO_PANEL_CONTROLLER = "gov.nasa.worldwindx.applications.worldwindow.feature.InfoPanelController";
+    String FEATURE_LAYER_MANAGER_DIALOG = "gov.nasa.worldwindx.applications.worldwindow.feature.LayerManagerDialog";
+    String FEATURE_LAYER_MANAGER = "gov.nasa.worldwindx.applications.worldwindow.feature.LayerManager";
+    String FEATURE_LAYER_MANAGER_PANEL = "gov.nasa.worldwindx.applications.worldwindow.feature.LayerManagerPanel";
+    String FEATURE_LATLON_GRATICULE = "gov.nasa.worldwindx.applications.worldwindow.feature.LatLonGraticule";
+    String FEATURE_MEASUREMENT = "gov.nasa.worldwindx.applications.worldwindow.feature.Measurement";
+    String FEATURE_MEASUREMENT_DIALOG = "gov.nasa.worldwindx.applications.worldwindow.feature.MeasurementDialog";
+    String FEATURE_MEASUREMENT_PANEL = "gov.nasa.worldwindx.applications.worldwindow.feature.MeasurementPanel";
+    String FEATURE_NAVIGATION = "gov.nasa.worldwindx.applications.worldwindow.feature.Navigation";
+    String FEATURE_OPEN_FILE = "gov.nasa.worldwindx.applications.worldwindow.feature.OpenFile";
+    String FEATURE_OPEN_URL = "gov.nasa.worldwindx.applications.worldwindow.feature.OpenURL";
+    String FEATURE_SCALE_BAR = "gov.nasa.worldwindx.applications.worldwindow.feature.ScaleBar";
+    String FEATURE_TOOLTIP_CONTROLLER = "gov.nasa.worldwindx.applications.worldwindow.feature.ToolTipController";
+    String FEATURE_UTM_GRATICULE = "gov.nasa.worldwindx.applications.worldwindow.feature.UTMGraticule";
+    String FEATURE_WMS_PANEL = "gov.nasa.worldwindx.applications.worldwindow.feature.WMSPanel";
+    String FEATURE_WMS_DIALOG = "gov.nasa.worldwindx.applications.worldwindow.feature.WMSDialog";
+
+    // Specific properties
+    String FEATURE_OWNER_PROPERTY = "gov.nasa.worldwindx.applications.worldwindow.FeatureOwnerProperty";
+    String TOOL_BAR_ICON_SIZE_PROPERTY = "gov.nasa.worldwindx.applications.worldwindow.ToolBarIconSizeProperty";
+}

--- a/src/gov/nasa/worldwind/util/MessageStrings.properties
+++ b/src/gov/nasa/worldwind/util/MessageStrings.properties
@@ -1262,6 +1262,20 @@ UnitsFormat.UTMEastingLabel=East
 UnitsFormat.UTMNorthingLabel=North
 UnitsFormat.TerrainHeightLabel=Terrain Height
 
+CMSUnitsFormat.LengthLabel=Length
+CMSUnitsFormat.LatitudeLabel=Latitude\u0020
+CMSUnitsFormat.LongitudeLabel=Longitude
+CMSUnitsFormat.LatLonLatLabel=Lat
+CMSUnitsFormat.LatLonLonLabel=Lon
+CMSUnitsFormat.HeadingLabel=Heading
+CMSUnitsFormat.EyeAltitudeLabel=Eye Altitude
+CMSUnitsFormat.PitchLabel=Pitch
+CMSUnitsFormat.DatumLabel=Datum
+CMSUnitsFormat.UTMZoneLabel=UTM Zone
+CMSUnitsFormat.UTMEastingLabel=East
+CMSUnitsFormat.UTMNorthingLabel=North
+CMSUnitsFormat.TerrainHeightLabel=Terrain Elevation
+
 URLRetriever.ErrorAttemptingToRetrieve=Error attempting to retrieve {0}
 URLRetriever.ErrorConfiguringProxy=Error configuring proxy host {0}
 URLRetriever.ErrorOpeningConnection=Error opening connection to {0}


### PR DESCRIPTION
…rely on worldwindx.examples classes anymore for the values and methods needed for the 'Coordinates Display' layer.  'Terrain Height' label is now 'Terrain Elevation' and the vertical exaggeration label, '(ve 1.0)' has been removed.

**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change

Added CMS specific copies of classes and constants in WorldWind Examples packages that provide the text constants for the "Coordinates Display" layer. 
Comments added to show changes made in CMSUnitsFormat.java method, 
- **public String terrainHeight(double metersElevation, double verticalExaggeration)**

I had to duplicate the string constants in _src/gov/nasa/worldwind/util/MessageStrings.properties_ to match the new class, **CMSUnitsFormat.java**, but this is a part of _worldwind/util_ and doesn't involve the WorldWindow packages anymore.  

In the future, the call to this resource bundle could be replaced with hard coded strings in order to further separate CMS from WorldWind.  

### Why Should This Be In Core?



### Benefits

### Potential Drawbacks

### Applicable Issues